### PR TITLE
Remove Yarn workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,6 @@
   "keywords": [],
   "author": "Grafana Labs <team@grafana.com> (https://grafana.com)",
   "license": "Apache-2.0",
-  "workspaces": [
-    "./fixtures/imports/**",
-    "poc3-bq"
-  ],
   "dependencies": {
     "chalk": "^4.1.2",
     "debug": "^4.3.2",


### PR DESCRIPTION
### What changed and why?
Removed the `./fixtures/imports` and `poc3-bq` directories from being inside a Yarn workspace **as it made it hard to publish the Levitate tool living at the "root" level of the repository.**

We can re-evaluate this later and decide how we would like to structure the repo. (We can even go back to the mono-repo structure and have this tool as one of the packages living in the repo).