### PR TITLE
Chore: bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/levitate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A tool for helping to understand APIs exported and consumed by NPM packages (or any TypeScript code).",
   "main": "dist/bin.js",
   "bin": {


### PR DESCRIPTION
### Why?
The only reason at this point is to validate that the CI workflows on `main` are working correctly by triggering them.