### PR TITLE
Feat: make it possible to run on single files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `levitate compare` now works on single files as well [#17](https://github.com/grafana/levitate/pull/17)
+
 ## [0.2.0] - 2022-01-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.1] - 2022-01-20
+
 ### Added
 
 - `levitate compare` now works on single files as well [#17](https://github.com/grafana/levitate/pull/17)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/levitate",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A tool for helping to understand APIs exported and consumed by NPM packages (or any TypeScript code).",
   "main": "dist/bin.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev:compare": "run-s build fixtures:compare",
     "dev:imports": "run-s build fixtures:imports",
     "dev:gobble": "run-s build fixtures:gobble",
-    "fixtures:compare": "DEBUG=* node ./dist/bin.js compare --prev @grafana/data@canary --current /Users/levente.balogh/grafana/grafana/packages/grafana-data/dist",
+    "fixtures:compare": "DEBUG=* node ./dist/bin.js compare --prev @grafana/ui@canary --current ./fixtures/compare/bundle-new.ts",
     "fixtures:imports": "DEBUG=* node ./dist/bin.js list-imports --path ./fixtures/imports/package/src/module.ts --filters @grafana/ui @grafana/data",
     "fixtures:gobble": "DEBUG=*:simple-git node ./dist/bin.js gobble --repositories 'https://github.com/grafana/clock-panel/' --filters @grafana/ui @grafana/data @grafana/runtime"
   },

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -31,7 +31,7 @@ yargs
         default: null,
         demandOption: true,
         describe:
-          "Previous package version - a name of an NPM package, a URL to a tar ball or a local path pointing to a package directory (Make sure it contains an `index.d.ts` type definition file.)",
+          "Previous package version - a name of an NPM package, a URL to a tar ball or a local path pointing to a package directory or a single file. (In case it is a directory make sure it contains an `index.d.ts` type definition file.)",
       });
 
       yargs.option("current", {
@@ -39,7 +39,7 @@ yargs
         default: null,
         demandOption: true,
         describe:
-          "Current package version - a name of an NPM package, a URL to a tar ball or a local path pointing to a package directory (Make sure it contains an `index.d.ts` type definition file.)",
+          "Current package version - a name of an NPM package, a URL to a tar ball or a local path pointing to a package directory or a single file. (In case it is a directory make sure it contains an `index.d.ts` type definition file.)",
       });
     },
     async function ({ prev, current }: { prev: string; current: string }) {


### PR DESCRIPTION
**What changed?**
- fixed a typo in the `package.json`
- updated the `levitate compare` command to run on single files as well (until now it could only run on NPM package names, URLs pointing to NPM packages or local folders) 