### PR TITLE
Chore: expose code from the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Expose code and TypeScript types from the package [#32](https://github.com/grafana/levitate/pull/32)
+
 ## [0.2.1] - 2022-01-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@grafana/levitate",
   "version": "0.2.1",
   "description": "A tool for helping to understand APIs exported and consumed by NPM packages (or any TypeScript code).",
-  "main": "dist/bin.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
     "levitate": "dist/bin.js"
   },
@@ -13,7 +14,7 @@
     "tdd": "LEVITATE_SILENT=true yarn test -- -o --watch",
     "test": "LEVITATE_SILENT=true yarn jest",
     "bundle": "ncc build ./src/bin.ts -o dist/ -C",
-    "build": "tsc ./src/bin.ts --m commonjs --outDir ./dist --esModuleInterop && chmod +x ./dist/bin.js",
+    "build": "tsc ./src/bin.ts ./src/index.ts --m commonjs --declaration --outDir ./dist --esModuleInterop && chmod +x ./dist/bin.js",
     "dev": "tsc-watch ./src/bin.ts --m commonjs --outDir ./dist --esModuleInterop",
     "dev-compare": "nodemon --exec yarn run dev:compare",
     "dev-imports": "nodemon --exec yarn run dev:imports",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./types";
+export * from "./utils.compare";
+export * from "./utils.compiler";
+export * from "./utils.compiler.imports";
+export * from "./utils.compiler.imports";
+export * from "./utils.diff";
+export * from "./utils.npm";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "jsx": "react",
     "declaration": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "jsx": "react"
+    "jsx": "react",
+    "declaration": true
   }
 }


### PR DESCRIPTION
**What changed?**
- exposing code from the package so the functionality can be reused in other packages
- exposing TypeScript types