### PR TITLE
Fix: yargs not executing commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev-imports": "nodemon --exec yarn run dev:imports",
     "dev:compare": "run-s build fixtures:compare",
     "dev:imports": "run-s build fixtures:imports",
-    "fixtures:compare": "DEBUG=* node ./dist/bin.js compare --prev @grafana/ui@canary --current ./fixtures/compare/bundle-new.ts",
+    "fixtures:compare": "DEBUG=* node ./dist/bin.js compare --prev @grafana/ui@canary --current @grafana/ui@latest",
     "fixtures:imports": "DEBUG=* node ./dist/bin.js list-imports --path ./fixtures/imports/package/src/module.ts --filters @grafana/ui @grafana/data"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tar": "^6.1.11",
     "tty-table": "^4.1.5",
     "typescript": "^4.5.2",
-    "yargs": "17.3.1"
+    "yargs": "^17.3.1"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/levitate",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A tool for helping to understand APIs exported and consumed by NPM packages (or any TypeScript code).",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tar": "^6.1.11",
     "tty-table": "^4.1.5",
     "typescript": "^4.5.2",
-    "yargs": "^17.2.1"
+    "yargs": "17.3.1"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     ],
     "ext": "*",
     "ignore": [
-      "repos/*"
+      "repos/*",
+      "dist/*"
     ],
     "events": {
       "start": "cls || clear"

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -46,8 +46,8 @@ yargs
         // Missing CLI arguments
         if (!prev || !current) {
           console.log("");
-          console.log(chalk.bgRed.bold.white(" ERROR "));
-          console.log("Missing arguments. Please make sure to provide both the --prev and --current options.\n");
+          console.error(chalk.bgRed.bold.white(" ERROR "));
+          console.error("Missing arguments. Please make sure to provide both the --prev and --current options.\n");
           yargs.showHelp();
           exit(1);
         }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -161,4 +161,5 @@ yargs
     function ({ path }: { path: string }) {
       printExports(getExportInfo(path));
     }
-  );
+  )
+  .help().argv;

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -43,6 +43,15 @@ yargs
     },
     async function ({ prev, current }: { prev: string; current: string }) {
       try {
+        // Missing CLI arguments
+        if (!prev || !current) {
+          console.log("");
+          console.log(chalk.bgRed.bold.white(" ERROR "));
+          console.log("Missing arguments. Please make sure to provide both the --prev and --current options.\n");
+          yargs.showHelp();
+          exit(1);
+        }
+
         const prevPathResolved = await resolvePackage(prev);
         const currentPathResolved = await resolvePackage(current);
         const comparison = compareExports(prevPathResolved, currentPathResolved);
@@ -56,14 +65,9 @@ yargs
       } catch (e) {
         console.log("");
         console.log(chalk.bgRed.bold.white(" ERROR "));
+        console.log(e);
 
-        if (e instanceof CliError) {
-          console.log(`ERROR: ${e.message}\n\n`);
-          yargs.showHelp();
-        } else {
-          console.log(e);
-          exit(1);
-        }
+        exit(1);
       }
     }
   )

--- a/src/utils.file.ts
+++ b/src/utils.file.ts
@@ -6,7 +6,6 @@ export function pathExists(path: string): boolean {
     fs.accessSync(path, fs.constants.R_OK);
     return true;
   } catch (e) {
-    logError(e);
     return false;
   }
 }

--- a/src/utils.npm.ts
+++ b/src/utils.npm.ts
@@ -119,6 +119,11 @@ export function getInstalledNpmPackagePath(packageName: string) {
 export async function downloadNpmPackageAsTarball(packageName: string) {
   const tmpFolderName = await createTmpPackageFolder(packageName);
   const url = await getPackageTarBallUrl(packageName);
+
+  if (!url) {
+    throw new Error(`Could not resolve package "${packageName}". Are you sure it exists?`);
+  }
+
   const tarballPath = path.join(tmpFolderName, path.basename(url));
 
   setSpinner(packageName, `Downloading tarball for ${packageName}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,6 +3956,19 @@ yargs-parser@^21.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
   integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
 
+yargs@17.3.1:
+  version "17.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.1.tgz#da56b28f32e2fd45aefb402ed9c26f42be4c07b9"
+  integrity sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"
+
 yargs@^15.1.0:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
@@ -3986,7 +3999,7 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.1.1, yargs@^17.2.1:
+yargs@^17.1.1:
   version "17.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.0.tgz#295c4ffd0eef148ef3e48f7a2e0f58d0e4f26b1c"
   integrity sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==


### PR DESCRIPTION
**Related Slack thread:** https://raintank-corp.slack.com/archives/C01C4K8DETW/p1643529613854559

**What was the problem?**
Since the latest version of `@grafana/levitate` commands were not executed by `yargs` at all.

**What changed?**
- added a `.argv` to the end of the yargs chain to solve the problem
- removed a noisy error log caused by `pathExists()`
- printing an error message and the command help if there are missing arguments for `@grafana/levitate compare`
- fixed the `yarn dev-compare` script ending up in an infinite loop
- bumped the version to `3.0.1` (will push a version tag for this, too)

Thanks a lot @joshhunt for finding the root cause! 🙌 
