### PR TITLE
Feat: Resolve type declaration file from package.json property

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.10",
     "@types/yargs": "^17.0.7",
+    "@typescript-eslint/parser": "^5.30.7",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "eslint": "^8.20.0",
     "eslint-config-prettier": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/levitate",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A tool for helping to understand APIs exported and consumed by NPM packages (or any TypeScript code).",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils.npm.ts
+++ b/src/utils.npm.ts
@@ -105,6 +105,17 @@ export async function createTmpPackageFolder(packageName: string) {
 }
 
 export function getTypeDefinitionFilePath(folder: string) {
+  const packageJson = getPackageJson(folder);
+
+  // if available use the package.json property that references a type definition file
+  if (packageJson) {
+    const typeProp = ['types', 'typings'].find((prop) => packageJson[prop] !== undefined);
+    if (typeProp) {
+      const typeDefinitionFilePath = packageJson[typeProp];
+      return path.join(folder, typeDefinitionFilePath);
+    }
+  }
+
   return path.join(folder, TYPE_DEFINITION_FILE_NAME);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,6 +718,16 @@
     "@typescript-eslint/typescript-estree" "5.16.0"
     debug "^4.3.2"
 
+"@typescript-eslint/parser@^5.30.7":
+  version "5.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.33.0.tgz#26ec3235b74f0667414613727cb98f9b69dc5383"
+  integrity sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.33.0"
+    "@typescript-eslint/types" "5.33.0"
+    "@typescript-eslint/typescript-estree" "5.33.0"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@5.16.0":
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.16.0.tgz#7e7909d64bd0c4d8aef629cdc764b9d3e1d3a69a"
@@ -733,6 +743,14 @@
   dependencies:
     "@typescript-eslint/types" "5.30.7"
     "@typescript-eslint/visitor-keys" "5.30.7"
+
+"@typescript-eslint/scope-manager@5.33.0":
+  version "5.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz#509d7fa540a2c58f66bdcfcf278a3fa79002e18d"
+  integrity sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==
+  dependencies:
+    "@typescript-eslint/types" "5.33.0"
+    "@typescript-eslint/visitor-keys" "5.33.0"
 
 "@typescript-eslint/type-utils@5.16.0":
   version "5.16.0"
@@ -762,6 +780,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.7.tgz#18331487cc92d0f1fb1a6f580c8ec832528079d0"
   integrity sha512-ocVkETUs82+U+HowkovV6uxf1AnVRKCmDRNUBUUo46/5SQv1owC/EBFkiu4MOHeZqhKz2ktZ3kvJJ1uFqQ8QPg==
 
+"@typescript-eslint/types@5.33.0":
+  version "5.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.33.0.tgz#d41c584831805554b063791338b0220b613a275b"
+  integrity sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==
+
 "@typescript-eslint/typescript-estree@5.16.0":
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.16.0.tgz#32259459ec62f5feddca66adc695342f30101f61"
@@ -782,6 +805,19 @@
   dependencies:
     "@typescript-eslint/types" "5.30.7"
     "@typescript-eslint/visitor-keys" "5.30.7"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.33.0":
+  version "5.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz#02d9c9ade6f4897c09e3508c27de53ad6bfa54cf"
+  integrity sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==
+  dependencies:
+    "@typescript-eslint/types" "5.33.0"
+    "@typescript-eslint/visitor-keys" "5.33.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -826,6 +862,14 @@
   integrity sha512-KrRXf8nnjvcpxDFOKej4xkD7657+PClJs5cJVSG7NNoCNnjEdc46juNAQt7AyuWctuCgs6mVRc1xGctEqrjxWw==
   dependencies:
     "@typescript-eslint/types" "5.30.7"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.33.0":
+  version "5.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz#fbcbb074e460c11046e067bc3384b5d66b555484"
+  integrity sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==
+  dependencies:
+    "@typescript-eslint/types" "5.33.0"
     eslint-visitor-keys "^3.3.0"
 
 abab@^2.0.3, abab@^2.0.5:


### PR DESCRIPTION
Until now Levitate has assumed the types declaration file lives in the root of the folder / package that is passed to it. However that's not always the case and can cause levitate to fail.

This PR adds the functionality to use the package.json file for a given folder path (if available) and return the location of the types declaration file from its `types` or `typings` property.

I also added `@typescript-eslint/parser` to stop yarn complaining on install about missing peer deps.

Bumping to `0.5.0` as I consider this a feature.

### before
```
$ DEBUG=* node ./dist/bin.js compare --prev @grafana/ui@canary --current @grafana/ui@latest
✖ Could not find type definition file at "/Users/jackwestbrook/Projects/levitate/@grafana/ui@canary/index.d.ts"

 ERROR 
Error: Could not find type definition file at "/Users/jackwestbrook/Projects/levitate/@grafana/ui@canary/index.d.ts"
    at /Users/jackwestbrook/Projects/levitate/dist/utils.npm.js:125:31
    at step (/Users/jackwestbrook/Projects/levitate/dist/utils.npm.js:63:23)
    at Object.next (/Users/jackwestbrook/Projects/levitate/dist/utils.npm.js:44:53)
    at fulfilled (/Users/jackwestbrook/Projects/levitate/dist/utils.npm.js:35:58)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: "fixtures:compare" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### after

```
$ DEBUG=* node ./dist/bin.js compare --prev @grafana/ui@canary --current @grafana/ui@latest
✔ Installed @grafana/ui@canary successfully
✔ Installed @grafana/ui@latest successfully
⠋ Detecting changes between versions  levitate Old filename: '/Users/jackwestbrook/Projects/levitate/.tmp/@grafana/ui@canary/package/dist/index.d.ts' +0ms
  levitate New filename: '/Users/jackwestbrook/Projects/levitate/.tmp/@grafana/ui@latest/package/index.d.ts' +1ms
  levitate Previous file: 425 exports +2s
  levitate Current file: 416 exports +0ms
✔ Successfully compared versions
  levitate Printing results... +1ms
```
