### PR TITLE
Detect function parameter types changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.4] - 2022-08-25
+
+- Detect changes in function parameters direct dependencies. Note: this won't work with more parameter types. [137](https://github.com/grafana/levitate/pull/137)
+
 ## [0.4.3] - 2022-08-22
 
 - Fixes an issue where re-exported types from files with a dot in the the filename were not read [131](https://github.com/grafana/levitate/pull/131)

--- a/fixtures/compare/bundle-new-props.tsx
+++ b/fixtures/compare/bundle-new-props.tsx
@@ -1,0 +1,10 @@
+type TestProps = {
+  foo: string;
+  bar: number[];
+};
+
+export class TestComponent<TestProps> {}
+
+// export function TestComponent2<TestProps>() {}
+//
+export function TestComponent3({ foo, bar }: TestProps) {}

--- a/fixtures/compare/bundle-old-props.tsx
+++ b/fixtures/compare/bundle-old-props.tsx
@@ -1,0 +1,11 @@
+type TestProps = {
+  foo: string;
+  bar: string[];
+};
+// export function TestComponent3({ foo, bar }: TestProps) {}
+
+export class TestComponent<TestProps> {}
+
+// export function TestComponent2<TestProps>() {}
+//
+export function TestComponent3({ foo, bar }: TestProps) {}

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testMatch: ['<rootDir>/src/**/*.test.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/levitate",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A tool for helping to understand APIs exported and consumed by NPM packages (or any TypeScript code).",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/levitate",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A tool for helping to understand APIs exported and consumed by NPM packages (or any TypeScript code).",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   "author": "Grafana Labs <team@grafana.com> (https://grafana.com)",
   "license": "Apache-2.0",
   "dependencies": {
+    "@types/diff": "^5.0.2",
     "chalk": "^4.1.2",
     "debug": "^4.3.2",
-    "diff": "^5.0.0",
+    "diff": "^5.1.0",
     "execa": "^5.1.1",
     "fast-glob": "^3.2.7",
     "node-fetch": "^2.6.6",

--- a/src/tests/utils.compare.test.ts
+++ b/src/tests/utils.compare.test.ts
@@ -1,15 +1,28 @@
-import path from 'path';
 import { compareExports } from '..';
 import { generateTmpFileWithContent } from './test-utils';
 
-const fixturesFolder = path.join(__dirname, '..', '..', 'fixtures', 'compare');
-
 describe('Utils compare tests', () => {
   it('should recognize changes in props for components', () => {
-    const oldBundle = path.join(fixturesFolder, 'bundle-old-props.tsx');
-    const newBundle = path.join(fixturesFolder, 'bundle-new-props.tsx');
+    const old = generateTmpFileWithContent(
+      `
+      type TestProps = {
+        foo: string;
+        bar: string[];
+      };
+      export function TestComponent({ foo, bar }: TestProps) {}
+      `
+    );
+    const newFile = generateTmpFileWithContent(
+      `
+      type TestProps = {
+        foo: string;
+        bar: number[]; // notice the change here
+      };
+      export function TestComponent({ foo, bar }: TestProps) {}
+      `
+    );
 
-    const comparison = compareExports(oldBundle, newBundle);
-    // console.log(comparison);
+    const comparison = compareExports(old, newFile);
+    expect(Object.keys(comparison.changes).length).toBe(1);
   });
 });

--- a/src/tests/utils.compare.test.ts
+++ b/src/tests/utils.compare.test.ts
@@ -1,0 +1,15 @@
+import path from 'path';
+import { compareExports } from '..';
+import { generateTmpFileWithContent } from './test-utils';
+
+const fixturesFolder = path.join(__dirname, '..', '..', 'fixtures', 'compare');
+
+describe('Utils compare tests', () => {
+  it('should recognize changes in props for components', () => {
+    const oldBundle = path.join(fixturesFolder, 'bundle-old-props.tsx');
+    const newBundle = path.join(fixturesFolder, 'bundle-new-props.tsx');
+
+    const comparison = compareExports(oldBundle, newBundle);
+    // console.log(comparison);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,9 +8,18 @@ export type SymbolMeta = {
 
 export type Exports = Record<string, ts.Symbol>;
 
+export enum ChangeType {
+  PARAMETER_TYPE = 'parameter-type',
+  PARAMETER_MISSING = 'parameter-missing',
+  PARAMETER_NAME = 'parameter-name',
+  PARAMETER_ADDITION = 'parameter-addition',
+}
+
 export type Change = {
   prev: ts.Symbol;
   current: ts.Symbol;
+  type?: ChangeType;
+  subChanges?: Change[];
 };
 
 export type Changes = Record<string, Change>;
@@ -52,6 +61,8 @@ export type Comparison = {
   changes: Changes;
   additions: Exports;
   removals: Exports;
+  prevProgram: ts.Program;
+  currentProgram: ts.Program;
 };
 
 export type CompareCLIArgs = {

--- a/src/utils.compare.ts
+++ b/src/utils.compare.ts
@@ -1,8 +1,10 @@
-import * as ts from 'typescript';
-import { SymbolMeta, Comparison } from './types';
+import ts from 'typescript';
+import { SymbolMeta, Comparison, Change } from './types';
 import { debug } from './utils.log';
 import { getExportInfo } from './utils.compiler.exports';
 import { startSpinner, setSpinner, succeedSpinner } from './utils.spinner';
+import { getSymbolFromParameter } from './utils.typescript';
+import { ChangeType } from '.';
 
 export function compareExports(prevRootFile: string, currentRootFile: string): Comparison {
   setSpinner('compare', 'Detecting changes between versions');
@@ -63,7 +65,7 @@ export function compareExports(prevRootFile: string, currentRootFile: string): C
 
   succeedSpinner('compare', 'Successfully compared versions');
 
-  return { changes, additions, removals };
+  return { changes, additions, removals, prevProgram: prev.program, currentProgram: current.program };
 }
 
 export function areChangesBreaking({ changes, removals }: Comparison) {
@@ -114,34 +116,50 @@ export function hasChanged(prev: SymbolMeta, current: SymbolMeta) {
   return false;
 }
 
-export function hasFunctionChanged(prev: SymbolMeta, current: SymbolMeta) {
+export function getFunctionParametersDiff({
+  prev,
+  current,
+}: {
+  prev: SymbolMeta;
+  current: SymbolMeta;
+}): Change | undefined {
   const prevDeclaration = prev.symbol.valueDeclaration as ts.FunctionDeclaration;
   const currentDeclaration = current.symbol.valueDeclaration as ts.FunctionDeclaration;
-
   // Check previous function parameters
   // (all previous parameters must be present at their previous position)
   for (let i = 0; i < prevDeclaration.parameters.length; i++) {
+    const prevParamType = prevDeclaration.parameters[i].type;
+    const prevParamSymbol = getSymbolFromParameter(prevDeclaration.parameters[i], prev.program);
+
     // No parameter at the same position
     if (!currentDeclaration.parameters[i]) {
-      return true;
+      return {
+        prev: prevParamSymbol,
+        current: null,
+        type: ChangeType.PARAMETER_MISSING,
+      };
     }
 
     // Changed parameter at the old position
     if (currentDeclaration.parameters[i].getText() !== prevDeclaration.parameters[i].getText()) {
-      return true;
+      const currentParamType = currentDeclaration.parameters[i]?.type || undefined;
+      const currentParamSymbol = getSymbolFromParameter(currentDeclaration.parameters[i], current.program);
+      return {
+        prev: prevParamSymbol,
+        current: currentParamSymbol,
+        type: ChangeType.PARAMETER_NAME,
+      };
     }
 
-    debugger;
-
-    // deeper compare parameter types
-    const currentParamType = currentDeclaration.parameters[i].type;
-    const prevParamType = prevDeclaration.parameters[i].type;
+    const currentParamType = currentDeclaration.parameters[i]?.type || undefined;
+    const currentParamSymbol = getSymbolFromParameter(currentDeclaration.parameters[i], current.program);
     if (ts.isTypeReferenceNode(currentParamType) && ts.isTypeReferenceNode(prevParamType)) {
-      const currentParamSymbol = current.program.getTypeChecker().getSymbolAtLocation(currentParamType.typeName);
-      const prevParamSymbol = prev.program.getTypeChecker().getSymbolAtLocation(prevParamType.typeName);
-
       if (currentParamSymbol.declarations[0].getText() !== prevParamSymbol.declarations[0].getText()) {
-        return true;
+        return {
+          prev: prevParamSymbol,
+          current: currentParamSymbol,
+          type: ChangeType.PARAMETER_TYPE,
+        };
       }
     }
   }
@@ -149,12 +167,27 @@ export function hasFunctionChanged(prev: SymbolMeta, current: SymbolMeta) {
   // Check current function parameters
   // (all current parameters must be optional)
   for (let i = 0; i < currentDeclaration.parameters.length; i++) {
+    const currentParamSymbol = getSymbolFromParameter(currentDeclaration.parameters[i], current.program);
     if (
       !prevDeclaration.parameters[i] &&
       !current.program.getTypeChecker().isOptionalParameter(currentDeclaration.parameters[i])
     ) {
-      return true;
+      return {
+        prev: null,
+        current: currentParamSymbol,
+        type: ChangeType.PARAMETER_ADDITION,
+      };
     }
+  }
+}
+
+export function hasFunctionChanged(prev: SymbolMeta, current: SymbolMeta) {
+  const prevDeclaration = prev.symbol.valueDeclaration as ts.FunctionDeclaration;
+  const currentDeclaration = current.symbol.valueDeclaration as ts.FunctionDeclaration;
+
+  const parameterChanges = getFunctionParametersDiff({ prev, current });
+  if (parameterChanges) {
+    return true;
   }
 
   // Check return type signatures -> they must be the same

--- a/src/utils.compare.ts
+++ b/src/utils.compare.ts
@@ -13,6 +13,7 @@ export function compareExports(prevRootFile: string, currentRootFile: string): C
 
   const prev = getExportInfo(prevRootFile);
   const current = getExportInfo(currentRootFile);
+
   const additions = {};
   const removals = {};
   const changes = {};
@@ -128,6 +129,20 @@ export function hasFunctionChanged(prev: SymbolMeta, current: SymbolMeta) {
     // Changed parameter at the old position
     if (currentDeclaration.parameters[i].getText() !== prevDeclaration.parameters[i].getText()) {
       return true;
+    }
+
+    debugger;
+
+    // deeper compare parameter types
+    const currentParamType = currentDeclaration.parameters[i].type;
+    const prevParamType = prevDeclaration.parameters[i].type;
+    if (ts.isTypeReferenceNode(currentParamType) && ts.isTypeReferenceNode(prevParamType)) {
+      const currentParamSymbol = current.program.getTypeChecker().getSymbolAtLocation(currentParamType.typeName);
+      const prevParamSymbol = prev.program.getTypeChecker().getSymbolAtLocation(prevParamType.typeName);
+
+      if (currentParamSymbol.declarations[0].getText() !== prevParamSymbol.declarations[0].getText()) {
+        return true;
+      }
     }
   }
 

--- a/src/utils.diff.ts
+++ b/src/utils.diff.ts
@@ -1,11 +1,12 @@
 import * as diff from 'diff';
 import chalk from 'chalk';
+import { ChangeType, getFunctionParametersDiff, isFunction, SymbolMeta } from '.';
 
 function getDiffLegend() {
   return '\n' + chalk.green('+ Added') + ' ' + chalk.red('- Removed') + '\n' + '\n';
 }
 
-export function getDiff(prev, current) {
+export function getDiff(prev: string, current: string) {
   const patch = diff.createPatch('string', prev, current);
   const lines = patch
     .split('\n')
@@ -13,7 +14,35 @@ export function getDiff(prev, current) {
     .map(getDiffForLine)
     .filter((line) => line !== null);
 
+  if (lines.length === 0 || !lines[0]) {
+    return '';
+  }
+
   return getDiffLegend() + lines.join('\n') + '\n';
+}
+
+export function getSymbolDiff({ prev, current }: { prev: SymbolMeta; current: SymbolMeta }) {
+  const prevDeclaration = prev.symbol.declarations[0].getText();
+  const currentDeclaration = current.symbol.declarations[0].getText();
+
+  if (isFunction(prev.symbol) && isFunction(current.symbol)) {
+    const functionDiffText = getDiff(prevDeclaration, currentDeclaration);
+    let paramsDiffText = '';
+    const parametersDiff = getFunctionParametersDiff({ prev, current });
+    if (parametersDiff && parametersDiff.type === ChangeType.PARAMETER_TYPE) {
+      paramsDiffText += chalk.yellow('parameter type changed\n');
+      try {
+        paramsDiffText += getDiff(
+          parametersDiff.prev.declarations[0].getText(),
+          parametersDiff.current.declarations[0].getText()
+        );
+      } catch (e) {
+        paramsDiffText = 'parameters -+-+-+-';
+      }
+    }
+    return functionDiffText + paramsDiffText;
+  }
+  return getDiff(prevDeclaration, currentDeclaration);
 }
 
 function getDiffForLine(line) {

--- a/src/utils.typescript.ts
+++ b/src/utils.typescript.ts
@@ -13,3 +13,17 @@ export function getAllIdentifiers(node: ts.Node | ts.SourceFile): ts.Identifier[
   });
   return identifiers;
 }
+
+export function getSymbolFromParameter(node: ts.ParameterDeclaration, program: ts.Program): ts.Symbol | undefined {
+  if (Object.hasOwnProperty.call(node, 'type') && ts.isTypeReferenceNode(node.type)) {
+    return program.getTypeChecker().getSymbolAtLocation(node.type.typeName);
+  }
+
+  if (Object.hasOwnProperty.call(node, 'symbol')) {
+    // seems to be an untyped ts property
+    // @ts-expect-error
+    return node.symbol as ts.Symbol;
+  }
+
+  return undefined;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -650,6 +650,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/diff@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@types/diff/-/diff-5.0.2.tgz#dd565e0086ccf8bc6522c6ebafd8a3125c91c12b"
+  integrity sha512-uw8eYMIReOwstQ0QKF0sICefSy8cNO/v7gOTiIy9SbwuHyEecJUm7qlgueOO5S1udZ5I/irVydHVwMchgzbKTg==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -1558,10 +1563,10 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-diff@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
-  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+diff@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 dir-glob@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Detect if the type of a function parameter changed between modules

e.g.:

old
```typescript
      type TestProps = {
        foo: string;
        bar: string[] // notice the change here
      };
      export function TestComponent({ foo, bar }: TestProps) {}
```

new
```typescript
      type TestProps = {
        foo: string;
        bar: number[]; // notice the change here
      };
      export function TestComponent({ foo, bar }: TestProps) {}

```

![image](https://user-images.githubusercontent.com/227916/186179974-f84dc4b5-6899-453c-b0b3-426a7197f9b6.png)
