### PR TITLE
Fix incompatibilities report not printing diff for function parameters incompatibility

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -107,7 +107,7 @@ yargs
         const isPathCompatible = await isCompatible(path, packages, { printIncompatibilities: true });
         if (isPathCompatible) {
           console.log('\n');
-          console.log(chalk.green(`${path} is compatible with ${target}`));
+          console.log(chalk.green(`${path} appears to be compatible with ${target}`));
         } else {
           console.log(chalk.red(`${path} is not fully compatible with ${target}`));
           console.log('Please read over the compatibility report above and update possible issues.');

--- a/src/commands/compare/compare.ts
+++ b/src/commands/compare/compare.ts
@@ -17,7 +17,7 @@ export function compareExports(prevRootFile: string, currentRootFile: string): C
 
   const additions = {};
   const removals = {};
-  const changes = {};
+  const changes: Record<string, Change> = {};
 
   debug('Previous file: %o exports', Object.keys(prev.exports).length);
   debug('Current file: %o exports', Object.keys(current.exports).length);
@@ -49,6 +49,8 @@ export function compareExports(prevRootFile: string, currentRootFile: string): C
         changes[currentExportName] = {
           prev: prev.exports[currentExportName],
           current: currentExportSymbol,
+          prevProgram: prev.program,
+          currentProgram: current.program,
         };
       }
     }
@@ -134,7 +136,9 @@ export function getFunctionParametersDiff({
     if (!currentDeclaration.parameters[i]) {
       return {
         prev: prevParamSymbol,
+        prevProgram: prev.program,
         current: null,
+        currentProgram: current.program,
         type: ChangeType.PARAMETER_MISSING,
       };
     }
@@ -144,7 +148,9 @@ export function getFunctionParametersDiff({
       const currentParamSymbol = getSymbolFromParameter(currentDeclaration.parameters[i], current.program);
       return {
         prev: prevParamSymbol,
+        prevProgram: prev.program,
         current: currentParamSymbol,
+        currentProgram: current.program,
         type: ChangeType.PARAMETER_NAME,
       };
     }
@@ -155,7 +161,9 @@ export function getFunctionParametersDiff({
       if (currentParamSymbol.declarations[0].getText() !== prevParamSymbol.declarations[0].getText()) {
         return {
           prev: prevParamSymbol,
+          prevProgram: prev.program,
           current: currentParamSymbol,
+          currentProgram: current.program,
           type: ChangeType.PARAMETER_TYPE,
         };
       }
@@ -172,7 +180,9 @@ export function getFunctionParametersDiff({
     ) {
       return {
         prev: null,
+        prevProgram: prev.program,
         current: currentParamSymbol,
+        currentProgram: current.program,
         type: ChangeType.PARAMETER_ADDITION,
       };
     }

--- a/src/print/incompatibilities.ts
+++ b/src/print/incompatibilities.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import Table from 'tty-table';
 import ts from 'typescript';
 import { IncompatibilityInfo } from '../types';
-import { getDiff, getSymbolDiff } from '../utils/diff';
+import { getSymbolDiff } from '../utils/diff';
 import { printHeading, printSpacing } from './utils';
 
 export function printIncompatibilities(incompatibilities: IncompatibilityInfo[]) {

--- a/src/print/incompatibilities.ts
+++ b/src/print/incompatibilities.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import Table from 'tty-table';
 import ts from 'typescript';
 import { IncompatibilityInfo } from '../types';
-import { getDiff } from '../utils/diff';
+import { getDiff, getSymbolDiff } from '../utils/diff';
 import { printHeading, printSpacing } from './utils';
 
 export function printIncompatibilities(incompatibilities: IncompatibilityInfo[]) {
@@ -39,9 +39,20 @@ export function printIncompatibilities(incompatibilities: IncompatibilityInfo[])
 
 function getIncompatibilityDetail(incompatibility: IncompatibilityInfo) {
   if (incompatibility.change) {
-    const prevDeclaration = incompatibility.change.prev.declarations[0].getText();
-    const currentDeclaration = incompatibility.change.current.declarations[0].getText();
-    return chalk.yellow('API Signature changed\n') + getDiff(prevDeclaration, currentDeclaration);
+    const diff = getSymbolDiff({
+      prev: {
+        key: incompatibility.change.prev.getName(),
+        symbol: incompatibility.change.prev,
+        program: incompatibility.change.prevProgram,
+      },
+      current: {
+        key: incompatibility.change.current.getName(),
+        symbol: incompatibility.change.current,
+        program: incompatibility.change.currentProgram,
+      },
+    });
+
+    return chalk.yellow('API Signature changed\n') + diff;
   }
 
   if (incompatibility.removal) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,8 @@ export enum ChangeType {
 export type Change = {
   prev: ts.Symbol;
   current: ts.Symbol;
+  prevProgram: ts.Program;
+  currentProgram: ts.Program;
   type?: ChangeType;
   subChanges?: Change[];
 };

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -23,7 +23,7 @@ export function getAllIdentifiers(node: ts.Node | ts.SourceFile): ts.Identifier[
 }
 
 export function getSymbolFromParameter(node: ts.ParameterDeclaration, program: ts.Program): ts.Symbol | undefined {
-  if (Object.hasOwnProperty.call(node, 'type') && ts.isTypeReferenceNode(node.type)) {
+  if (program && Object.hasOwnProperty.call(node, 'type') && ts.isTypeReferenceNode(node.type)) {
     return program.getTypeChecker().getSymbolAtLocation(node.type.typeName);
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "declaration": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "noUnusedLocals": true
   },
   "exclude": ["./dist", "./fixtures"],
   "files": ["./src/bin.ts"]


### PR DESCRIPTION
Closes: https://github.com/grafana/levitate/issues/157

This PR adds the required logic to display the diff for incompatibilities between function parameters. (e.g. component props)

![image](https://user-images.githubusercontent.com/227916/188817339-9e17698d-ae50-4103-8156-e626546e6831.png)
