### PR TITLE
rename inner methods and improve temporal folder management

### DIFF
--- a/.vimspector.json
+++ b/.vimspector.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json",
   "configurations": {
-    "run": {
+    "AttchToDebugger": {
       "adapter": "vscode-node",
       "breakpoints": {
         "exception": {
@@ -11,7 +11,26 @@
       },
       "configuration": {
         "request": "attach",
-        "protocol": "auto"
+        "protocol": "auto",
+        "console": "integratedTerminal"
+      }
+    },
+    "JestDebugger": {
+      "adapter": "vscode-node",
+      "breakpoints": {
+        "exception": {
+          "all": "N",
+          "uncaught": "Y"
+        }
+      },
+      "configuration": {
+        "request": "launch",
+        "name": "Jest debugger",
+        "type": "node",
+        "console": "integratedTerminal",
+        "program": "${workspaceRoot}/node_modules/.bin/jest",
+        "args": ["${file}"],
+        "cwd": "${workspaceRoot}"
       }
     }
   }

--- a/.vimspector.json
+++ b/.vimspector.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json",
+  "configurations": {
+    "run": {
+      "adapter": "vscode-node",
+      "breakpoints": {
+        "exception": {
+          "all": "N",
+          "uncaught": "Y"
+        }
+      },
+      "configuration": {
+        "request": "attach",
+        "protocol": "auto"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ora": "5.4.1",
     "tar": "^6.1.11",
     "tty-table": "^4.1.5",
-    "typescript": "^4.5.2",
+    "typescript": "4.8.2",
     "yargs": "^17.3.1"
   },
   "devDependencies": {

--- a/src/commands/compare/compare.ts
+++ b/src/commands/compare/compare.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import { Change, ChangeType, Comparison, SymbolMeta } from '../../types';
 import { setSpinner, startSpinner, succeedSpinner } from '../../utils/spinner';
-import { debug } from '../../utils/log';
+import { logDebug } from '../../utils/log';
 import { getExportInfo } from '../../compiler/exports';
 import { getSymbolFromParameter } from '../../utils/typescript';
 
@@ -9,8 +9,8 @@ export function compareExports(prevRootFile: string, currentRootFile: string): C
   setSpinner('compare', 'Detecting changes between versions');
   startSpinner('compare');
 
-  debug('Old filename: %o', prevRootFile);
-  debug('New filename: %o', currentRootFile);
+  logDebug('Old filename: %o', prevRootFile);
+  logDebug('New filename: %o', currentRootFile);
 
   const prev = getExportInfo(prevRootFile);
   const current = getExportInfo(currentRootFile);
@@ -19,8 +19,8 @@ export function compareExports(prevRootFile: string, currentRootFile: string): C
   const removals = {};
   const changes: Record<string, Change> = {};
 
-  debug('Previous file: %o exports', Object.keys(prev.exports).length);
-  debug('Current file: %o exports', Object.keys(current.exports).length);
+  logDebug('Previous file: %o exports', Object.keys(prev.exports).length);
+  logDebug('Current file: %o exports', Object.keys(current.exports).length);
 
   // Look for changes introduced by the current version
   for (const [currentExportName, currentExportSymbol] of Object.entries(current.exports)) {
@@ -77,37 +77,37 @@ export function areChangesBreaking({ changes, removals }: Comparison) {
 // (Tip: use https://ts-ast-viewer.com for discovering certain types more easily)
 export function hasChanged(prev: SymbolMeta, current: SymbolMeta) {
   if (isFunction(current.symbol) && isFunction(prev.symbol)) {
-    debug(`Checking changes for "${current.key}" (Function)`);
+    logDebug(`Checking changes for "${current.key}" (Function)`);
     return hasFunctionChanged(prev, current);
   }
 
   if (isMethod(current.symbol) && isMethod(prev.symbol)) {
-    debug(`Checking changes for "${current.key}" (Method)`);
+    logDebug(`Checking changes for "${current.key}" (Method)`);
     return hasFunctionChanged(prev, current);
   }
 
   if (isClass(current.symbol) && isClass(prev.symbol)) {
-    debug(`Checking changes for "${current.key}" (Class)`);
+    logDebug(`Checking changes for "${current.key}" (Class)`);
     return hasClassChanged(prev, current);
   }
 
   if (isVariable(current.symbol) && isVariable(prev.symbol)) {
-    debug(`Checking changes for "${current.key}" (Variable)`);
+    logDebug(`Checking changes for "${current.key}" (Variable)`);
     return hasVariableChanged(prev, current);
   }
 
   if (isInterface(current.symbol) && isInterface(prev.symbol)) {
-    debug(`Checking changes for "${current.key}" (Interface)`);
+    logDebug(`Checking changes for "${current.key}" (Interface)`);
     return hasInterfaceChanged(prev, current);
   }
 
   if (isEnum(current.symbol) && isEnum(prev.symbol)) {
-    debug(`Checking changes for "${current.key}" (Enum)`);
+    logDebug(`Checking changes for "${current.key}" (Enum)`);
     return hasEnumChanged(prev, current);
   }
 
   if (isType(current.symbol) && isType(prev.symbol)) {
-    debug(`Checking changes for "${current.key}" (Type)`);
+    logDebug(`Checking changes for "${current.key}" (Type)`);
     return hasTypeChanged(prev, current);
   }
 

--- a/src/commands/is-compatible/is-compatible.test.ts
+++ b/src/commands/is-compatible/is-compatible.test.ts
@@ -1,6 +1,6 @@
 import { getIncompatibilitiesFromComparison } from '../../comparison/source';
 import { generateTmpFileWithContent } from '../../tests/test-utils';
-import { createProgram } from '../../utils/typescript';
+import { createTsProgram } from '../../utils/typescript';
 import { testCompare } from '../compare/utils';
 
 const prevAPIWithoutChange = `
@@ -43,7 +43,7 @@ describe('is compatible command', () => {
           two: 1234,
         }
     `);
-    const program = createProgram(file);
+    const program = createTsProgram(file);
     const sourceFile = program.getSourceFile(file);
     const result = getIncompatibilitiesFromComparison(sourceFile, comparison);
     expect(result).toHaveLength(3);

--- a/src/commands/is-compatible/is-compatible.ts
+++ b/src/commands/is-compatible/is-compatible.ts
@@ -3,7 +3,7 @@ import { printIncompatibilities } from '../../print/incompatibilities';
 import { PackageWithVersion } from '../../types';
 import { getIncompatibilitiesBetweenPackages } from '../../comparison/source';
 import { getNpmPackageVersionFromProjectPath } from '../../utils/npm';
-import { createProgram } from '../../utils/typescript';
+import { createTsProgram } from '../../utils/typescript';
 
 export async function isCompatible(
   projectPath: string,
@@ -12,7 +12,7 @@ export async function isCompatible(
     printIncompatibilities: boolean;
   }
 ): Promise<boolean> {
-  const projectProgram = createProgram(projectPath);
+  const projectProgram = createTsProgram(projectPath);
   let isPathCompatible = true;
   for (const pkg of packagesToCheck) {
     console.log(

--- a/src/comparison/source.ts
+++ b/src/comparison/source.ts
@@ -1,6 +1,7 @@
 import ts from 'typescript';
 import { compareExports } from '../commands/compare/compare';
 import { Comparison, IncompatibilityInfo } from '../types';
+import { logDebug } from '../utils/log';
 import { resolvePackage } from '../utils/npm';
 import { getAllIdentifiers } from '../utils/typescript';
 
@@ -11,6 +12,7 @@ export async function getIncompatibilitiesBetweenPackages(
 ): Promise<IncompatibilityInfo[]> {
   const fromPathResolved = await resolvePackage(pkgFrom);
   const toPathResolved = await resolvePackage(pkgTo);
+  logDebug("Comparing '" + fromPathResolved + "' to '" + toPathResolved + "'");
   const comparison = compareExports(fromPathResolved, toPathResolved);
   const incompatibilities: IncompatibilityInfo[] = [];
   for (const sourceFile of program.getSourceFiles()) {

--- a/src/compiler/exports.ts
+++ b/src/compiler/exports.ts
@@ -1,11 +1,11 @@
 import ts from 'typescript';
 import { Exports, ExportsInfo } from '../types';
-import { createProgram } from '../utils/typescript';
+import { createTsProgram } from '../utils/typescript';
 
 // Returns all the exported members of a program identified by a root file (entry file)
 // @param rootFile - Has to be an absolute path
 export function getExportInfo(rootFile: string): ExportsInfo {
-  const program = createProgram(rootFile);
+  const program = createTsProgram(rootFile);
   const programExports = getExportedSymbolsForProgram(program);
 
   return {

--- a/src/compiler/imports.ts
+++ b/src/compiler/imports.ts
@@ -1,9 +1,9 @@
 import ts from 'typescript';
 import { ImportInfo, ImportsInfo } from '../types';
-import { createProgram } from '../utils/typescript';
+import { createTsProgram } from '../utils/typescript';
 
 export function getImportsInfo(rootFile: string, filters?: string[]): ImportsInfo {
-  const program = createProgram(rootFile);
+  const program = createTsProgram(rootFile);
   const programImports = getImportsForProgram(program, filters);
 
   return {

--- a/src/print/comparison.ts
+++ b/src/print/comparison.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { Comparison, Exports } from '../types';
-import { debug } from '../utils/log';
+import { logDebug } from '../utils/log';
 import { printChanges } from './changes';
 import { printRemovals } from './removals';
 import { printHeading, printSpacing } from './utils';
@@ -9,7 +9,7 @@ import Table from 'tty-table';
 import { areChangesBreaking } from '../commands/compare/compare';
 
 export function printComparison({ changes, additions, removals, prevProgram, currentProgram }: Comparison) {
-  debug('Printing results...');
+  logDebug('Printing results...');
   const isBreaking = areChangesBreaking({ changes, additions, removals, prevProgram, currentProgram });
 
   printAdditions(additions);

--- a/src/print/exports.ts
+++ b/src/print/exports.ts
@@ -1,8 +1,8 @@
 import { ExportsInfo } from '../types';
-import { debug } from '../utils/log';
+import { logDebug } from '../utils/log';
 
 export function printExports(exports: ExportsInfo) {
-  debug('Printing results...');
+  logDebug('Printing results...');
 
   console.log('');
   console.log('List of exported members:');

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,6 +1,6 @@
 import getDebug from 'debug';
 
-export const debug = getDebug('levitate');
+export const logDebug = getDebug('levitate');
 
 export const logError = (...args: any[]) => {
   if (!isSilent()) {

--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -3,12 +3,13 @@ import fs from 'fs';
 import fetch from 'node-fetch';
 import path, { dirname } from 'path';
 import tar from 'tar';
+import os from 'os';
 import { NpmList, PackageWithVersion } from '../types';
 import { pathExists } from './file';
 import { failSpinner, setSpinner, startSpinner, succeedSpinner } from './spinner';
+import { logDebug } from './log';
 
 export const TYPE_DEFINITION_FILE_NAME = 'index.d.ts';
-export const TMP_FOLDER = '.tmp';
 export const SPINNERS = [];
 const shouldCacheExternal = !!process.env.LEVITATE_CACHE || false;
 // The `packageName` is a string that can be any of the following:
@@ -83,7 +84,7 @@ export async function uninstallPackage(packageName: string) {
 }
 
 export function getTmpFolderName(packageName: string) {
-  return path.resolve(path.join(__dirname, '..', TMP_FOLDER, packageName));
+  return path.resolve(path.join(os.tmpdir(), packageName));
 }
 
 export async function removeTmpFolder(packageName: string) {
@@ -98,6 +99,7 @@ export async function removeTmpFolder(packageName: string) {
 export async function createTmpPackageFolder(packageName: string) {
   const tmpPackageFolder = getTmpFolderName(packageName);
 
+  logDebug(`Creating tmp folder at ${tmpPackageFolder} for ${packageName}`);
   setSpinner(packageName, `Creating temporary folder for "${packageName}"`);
   await removeTmpFolder(packageName);
 

--- a/src/utils/typescript.test.ts
+++ b/src/utils/typescript.test.ts
@@ -1,4 +1,4 @@
-import { createProgram } from '..';
+import { createTsProgram } from '..';
 import { generateTmpFileWithContent } from '../tests/test-utils';
 import { getAllIdentifiers } from '../utils/typescript';
 
@@ -15,7 +15,7 @@ describe('Typescript utils', () => {
           return 1;
         }
     `);
-    const program = createProgram(filePath);
+    const program = createTsProgram(filePath);
     const sourceFile = program.getSourceFile(filePath);
     const identifiers = getAllIdentifiers(sourceFile);
     expect(identifiers.length).toBe(10);

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -36,7 +36,7 @@ export function getSymbolFromParameter(node: ts.ParameterDeclaration, program: t
   return undefined;
 }
 
-export function createProgram(fileName: string): ts.Program {
+export function createTsProgram(fileName: string): ts.Program {
   const program = ts.createProgram([fileName], COMPILER_OPTIONS);
 
   program.getTypeChecker();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4579,10 +4579,10 @@ typescript@4.6.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
-typescript@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
+typescript@4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
+  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Putting these changes in a smaller PR to prepare the ground for the `getUsages` API.

* Set the typescript version to exact
* Rename some conflicting export names to avoid IDE confusions
* Add viminspector file for easier debugging 
* Use os.tmpdir() to create temporal directories instead of `.tmp`
