### PR TITLE
Fix symbol not reporting members for esm packages

### DIFF
--- a/src/commands/compare/types.test.ts
+++ b/src/commands/compare/types.test.ts
@@ -52,7 +52,7 @@ describe('Compare types', () => {
     const comparison = testCompare(prev, current);
 
     expect(Object.keys(comparison.changes)).toEqual(['Foo', 'Bar']);
-    expect(Object.keys(comparison.additions).length).toBe(0);
+    expect(Object.keys(comparison.additions).length).toBe(1);
     expect(Object.keys(comparison.removals).length).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/grafana/levitate/issues/216

Some packages using ESM don't report members and exports directly on the symbols coming from exported members. This PR adds an additional path finding for those members and exports for those cases.
