### PR TITLE
Fix: Native types don't have declarations

### DIFF
--- a/src/commands/compare/compare.ts
+++ b/src/commands/compare/compare.ts
@@ -157,6 +157,12 @@ export function getFunctionParametersDiff({
 
     const currentParamType = currentDeclaration.parameters[i]?.type || undefined;
     const currentParamSymbol = getSymbolFromParameter(currentDeclaration.parameters[i], current.program);
+
+    // native types (e.g. MouseEvent) don't have declarations
+    if (!currentParamSymbol.declarations || !prevParamSymbol.declarations) {
+      return;
+    }
+
     if (ts.isTypeReferenceNode(currentParamType) && ts.isTypeReferenceNode(prevParamType)) {
       if (currentParamSymbol.declarations[0].getText() !== prevParamSymbol.declarations[0].getText()) {
         return {


### PR DESCRIPTION
Fixes an exception that could happen when exported functions use native types that don't usually have declarations in typescript.