### PR TITLE
Do not report breaking changes when removing "declare" from type

### DIFF
--- a/src/commands/compare/compare.ts
+++ b/src/commands/compare/compare.ts
@@ -387,7 +387,7 @@ export function hasTypeChanged(prev: SymbolMeta, current: SymbolMeta) {
   // Changed if anything has changed.
   // (This is a bit tricky, as a type declaration can be a `FunctionType`, a `UnionType`, a `TypeLiteral`, etc. A `TypeLiteral` should need to be checked similarly to a Class or an Interface.)
   // TODO: revisit how much trouble "false negatives" coming from this are causing us.
-  if (isTypexTextEqual(prevDeclaration.getText(), currentDeclaration.getText())) {
+  if (!isTypexTextEqual(prevDeclaration.getText(), currentDeclaration.getText())) {
     return true;
   }
 
@@ -395,8 +395,7 @@ export function hasTypeChanged(prev: SymbolMeta, current: SymbolMeta) {
 }
 
 function isTypexTextEqual(a: string, b: string) {
-  // we want to ignore if `declare` is present in the text
-  return a.replace(/\sdeclare\/s/, 'i') === b.replace(/\sdeclare\/s/, 'i');
+  return a.replace(/\sdeclare\s/i, ' ') === b.replace(/\sdeclare\s/i, ' ');
 }
 
 export function isFunction(symbol: ts.Symbol) {

--- a/src/commands/compare/compare.ts
+++ b/src/commands/compare/compare.ts
@@ -364,7 +364,9 @@ export function hasEnumChanged(prev: SymbolMeta, current: SymbolMeta) {
   // (all previous members must be left intact, otherwise any code that depends on them can possibly have type errors)
   for (let i = 0; i < prevDeclaration.members.length; i++) {
     const prevMemberText = prevDeclaration.members[i].getText();
-    const currentMember = currentDeclaration.members.find((member) => prevMemberText === member.getText());
+    const currentMember = currentDeclaration.members.find((member) => {
+      return isTypexTextEqual(prevMemberText, member.getText());
+    });
 
     // Member is missing in the current declaration, or has changed
     if (!currentMember) {
@@ -385,11 +387,16 @@ export function hasTypeChanged(prev: SymbolMeta, current: SymbolMeta) {
   // Changed if anything has changed.
   // (This is a bit tricky, as a type declaration can be a `FunctionType`, a `UnionType`, a `TypeLiteral`, etc. A `TypeLiteral` should need to be checked similarly to a Class or an Interface.)
   // TODO: revisit how much trouble "false negatives" coming from this are causing us.
-  if (prevDeclaration.getText() !== currentDeclaration.getText()) {
+  if (isTypexTextEqual(prevDeclaration.getText(), currentDeclaration.getText())) {
     return true;
   }
 
   return false;
+}
+
+function isTypexTextEqual(a: string, b: string) {
+  // we want to ignore if `declare` is present in the text
+  return a.replace(/\sdeclare\/s/, 'i') === b.replace(/\sdeclare\/s/, 'i');
 }
 
 export function isFunction(symbol: ts.Symbol) {

--- a/src/commands/compare/enums.test.ts
+++ b/src/commands/compare/enums.test.ts
@@ -114,4 +114,44 @@ describe('Compare enums', () => {
     expect(Object.keys(comparison.additions).length).toBe(1);
     expect(Object.keys(comparison.removals).length).toBe(1);
   });
+
+  test('Removing "declare" from a symbol should not trigger a breaking change', () => {
+    const prev = `
+      export declare enum Bar = {
+        Append = 'append',
+        Replace = 'replace',
+      }
+    `;
+    const current = `
+      export enum Bar = {
+        Append = 'append',
+        Replace = 'replace',
+      }
+    `;
+    const comparison = testCompare(prev, current);
+
+    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(Object.keys(comparison.additions).length).toBe(0);
+    expect(Object.keys(comparison.changes).length).toBe(0);
+  });
+
+  test('Adding "declare" to a symbol should not trigger a breaking change', () => {
+    const prev = `
+      export enum Bar = {
+        Append = 'append',
+        Replace = 'replace',
+      }
+    `;
+    const current = `
+      export declare enum Bar = {
+        Append = 'append',
+        Replace = 'replace',
+      }
+    `;
+    const comparison = testCompare(prev, current);
+
+    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(Object.keys(comparison.additions).length).toBe(0);
+    expect(Object.keys(comparison.changes).length).toBe(0);
+  });
 });

--- a/src/commands/compare/types.test.ts
+++ b/src/commands/compare/types.test.ts
@@ -55,4 +55,84 @@ describe('Compare types', () => {
     expect(Object.keys(comparison.additions).length).toBe(1);
     expect(Object.keys(comparison.removals).length).toBe(0);
   });
+
+  test('Removing "Export" from a symbol should trigger a breaking change', () => {
+    const prev = `
+      export type Bar = {
+        one: string;
+        two: number;
+      }
+    `;
+    const current = `
+      type Bar = {
+        one: string;
+        two: number;
+      }
+    `;
+    const comparison = testCompare(prev, current);
+
+    expect(Object.keys(comparison.removals)).toEqual(['Bar', 'Bar.one', 'Bar.two']);
+    expect(Object.keys(comparison.additions).length).toBe(0);
+    expect(Object.keys(comparison.removals).length).toBe(3);
+  });
+
+  test('Removing "declare" from a symbol should not trigger a breaking change', () => {
+    const prev = `
+      declare type Bar = {
+        one: string;
+        two: number;
+      }
+    `;
+    const current = `
+      type Bar = {
+        one: string;
+        two: number;
+      }
+    `;
+    const comparison = testCompare(prev, current);
+
+    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(Object.keys(comparison.additions).length).toBe(0);
+    expect(Object.keys(comparison.removals).length).toBe(0);
+  });
+
+  test('Adding "declare" from a symbol should not trigger a breaking change', () => {
+    const prev = `
+      type Bar = {
+        one: string;
+        two: number;
+      }
+    `;
+    const current = `
+      declare type Bar = {
+        one: string;
+        two: number;
+      }
+    `;
+    const comparison = testCompare(prev, current);
+
+    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(Object.keys(comparison.additions).length).toBe(0);
+    expect(Object.keys(comparison.removals).length).toBe(0);
+  });
+
+  test('', () => {
+    const prev = `
+      type Bar = {
+        one: string;
+        two: number;
+      }
+    `;
+    const current = `
+      declare type Bar = {
+        one: string;
+        two: number;
+      }
+    `;
+    const comparison = testCompare(prev, current);
+
+    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(Object.keys(comparison.additions).length).toBe(0);
+    expect(Object.keys(comparison.removals).length).toBe(0);
+  });
 });

--- a/src/commands/compare/types.test.ts
+++ b/src/commands/compare/types.test.ts
@@ -116,7 +116,7 @@ describe('Compare types', () => {
     expect(Object.keys(comparison.removals).length).toBe(0);
   });
 
-  test('', () => {
+  test('Adding "declare" from a symbol should not trigger a breaking change', () => {
     const prev = `
       type Bar = {
         one: string;

--- a/src/commands/compare/types.test.ts
+++ b/src/commands/compare/types.test.ts
@@ -73,18 +73,19 @@ describe('Compare types', () => {
 
     expect(Object.keys(comparison.removals)).toEqual(['Bar', 'Bar.one', 'Bar.two']);
     expect(Object.keys(comparison.additions).length).toBe(0);
+    expect(Object.keys(comparison.changes).length).toBe(0);
     expect(Object.keys(comparison.removals).length).toBe(3);
   });
 
-  test('Removing "declare" from a symbol should not trigger a breaking change', () => {
+  test.only('Removing "declare" from a symbol should not trigger a breaking change', () => {
     const prev = `
-      declare type Bar = {
+      export declare type Bar = {
         one: string;
         two: number;
       }
     `;
     const current = `
-      type Bar = {
+      export type Bar = {
         one: string;
         two: number;
       }
@@ -93,18 +94,18 @@ describe('Compare types', () => {
 
     expect(Object.keys(comparison.removals).length).toBe(0);
     expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(Object.keys(comparison.changes).length).toBe(0);
   });
 
-  test('Adding "declare" from a symbol should not trigger a breaking change', () => {
+  test.skip('Adding "declare" from a symbol should not trigger a breaking change', () => {
     const prev = `
-      type Bar = {
+      export type Bar = {
         one: string;
         two: number;
       }
     `;
     const current = `
-      declare type Bar = {
+      export declare type Bar = {
         one: string;
         two: number;
       }
@@ -113,26 +114,24 @@ describe('Compare types', () => {
 
     expect(Object.keys(comparison.removals).length).toBe(0);
     expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(Object.keys(comparison.changes).length).toBe(0);
   });
 
-  test('Adding "declare" from a symbol should not trigger a breaking change', () => {
-    const prev = `
-      type Bar = {
-        one: string;
-        two: number;
-      }
-    `;
-    const current = `
-      declare type Bar = {
-        one: string;
-        two: number;
-      }
-    `;
-    const comparison = testCompare(prev, current);
-
-    expect(Object.keys(comparison.removals).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
-  });
+  // test.only('Adding an optional type should trigger a breaking change', () => {
+  //   const prev = `
+  //     type Bar = {
+  //       one: string;
+  //       two: number;
+  //     }
+  //   `;
+  //   const current = `
+  //   `;
+  //   const comparison = testCompare(prev, current);
+  //   console.log(comparison.removals);
+  //   expect(Object.keys(comparison.removals).length).toBe(0);
+  //   expect(Object.keys(comparison.additions).length).toBe(0);
+  //   expect(Object.keys(comparison.changes).length).toBe(0);
+  //   // expect(Object.keys(comparison.changes).length).toBe(1);
+  //   // expect(Object.keys(comparison.changes).includes('Bar.two')).toBe(true);
+  // });
 });

--- a/src/commands/compare/types.test.ts
+++ b/src/commands/compare/types.test.ts
@@ -77,7 +77,7 @@ describe('Compare types', () => {
     expect(Object.keys(comparison.removals).length).toBe(3);
   });
 
-  test.only('Removing "declare" from a symbol should not trigger a breaking change', () => {
+  test('Removing "declare" from a symbol should not trigger a breaking change', () => {
     const prev = `
       export declare type Bar = {
         one: string;
@@ -97,7 +97,7 @@ describe('Compare types', () => {
     expect(Object.keys(comparison.changes).length).toBe(0);
   });
 
-  test.skip('Adding "declare" from a symbol should not trigger a breaking change', () => {
+  test('Adding "declare" to a symbol should not trigger a breaking change', () => {
     const prev = `
       export type Bar = {
         one: string;
@@ -116,22 +116,4 @@ describe('Compare types', () => {
     expect(Object.keys(comparison.additions).length).toBe(0);
     expect(Object.keys(comparison.changes).length).toBe(0);
   });
-
-  // test.only('Adding an optional type should trigger a breaking change', () => {
-  //   const prev = `
-  //     type Bar = {
-  //       one: string;
-  //       two: number;
-  //     }
-  //   `;
-  //   const current = `
-  //   `;
-  //   const comparison = testCompare(prev, current);
-  //   console.log(comparison.removals);
-  //   expect(Object.keys(comparison.removals).length).toBe(0);
-  //   expect(Object.keys(comparison.additions).length).toBe(0);
-  //   expect(Object.keys(comparison.changes).length).toBe(0);
-  //   // expect(Object.keys(comparison.changes).length).toBe(1);
-  //   // expect(Object.keys(comparison.changes).includes('Bar.two')).toBe(true);
-  // });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,10 +31,15 @@ export type ExportsInfo = {
   program: ts.Program;
 };
 
+export type IgnoreOptions = {
+  ignoreOptionalAdditions?: boolean;
+};
+
 export type IgnoreExportChanges = {
   additions?: RegExp[];
   removals?: RegExp[];
   changes?: RegExp[];
+  options?: IgnoreOptions;
 };
 
 export type ImportInfo = {


### PR DESCRIPTION
review https://github.com/grafana/levitate/pull/358 instead of this.


Closes https://github.com/grafana/levitate/issues/231

Example

```
    const prev = `
      export type Bar = {
        one: string;
        two: number;
      }
    `;

    const current = `
      export declare type Bar = { // won't trigger a change anymore
        one: string;
        two: number;
      }
    `;

```
