### PR TITLE
Use @tsd/typescript and internal typescript methods to compare types instead of text diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "author": "Grafana Labs <team@grafana.com> (https://grafana.com)",
   "license": "Apache-2.0",
   "dependencies": {
+    "@tsd/typescript": "^5.3.2",
     "@types/node": "^20.9.3",
     "chalk": "^4.1.2",
     "debug": "^4.3.2",

--- a/src/commands/compare/compare.ts
+++ b/src/commands/compare/compare.ts
@@ -298,13 +298,11 @@ export function hasVariableChanged(prev: SymbolMeta, current: SymbolMeta) {
   const prevDeclaration = prev.symbol.declarations[0] as ts.VariableDeclaration;
   const currentDeclaration = current.symbol.declarations[0] as ts.VariableDeclaration;
 
-  // Changed if anything has changed in its type signature
-  // (any type changes can cause issues in the code that depends on them)
-  if (prevDeclaration.getText() !== currentDeclaration.getText()) {
-    return true;
-  }
+  const checker = prev.program.getTypeChecker();
+  const prevType = checker.getTypeAtLocation(prevDeclaration);
+  const currentType = checker.getTypeAtLocation(currentDeclaration);
 
-  return false;
+  return !checker.isTypeIdenticalTo(prevType, currentType);
 }
 
 export function hasClassChanged(prev: SymbolMeta, current: SymbolMeta) {

--- a/src/commands/compare/compare.ts
+++ b/src/commands/compare/compare.ts
@@ -371,7 +371,7 @@ export function hasTypeChanged(prev: SymbolMeta, current: SymbolMeta) {
 
   // first try a fast text comparison
   // this is required because ENUM individual elements
-  // are not comparable with the type checker
+  // are not comparable with the type checker internal mechanism
   if (prevDeclaration.getText() === currentDeclaration.getText()) {
     return false;
   }

--- a/src/commands/compare/compare.ts
+++ b/src/commands/compare/compare.ts
@@ -360,22 +360,11 @@ export function hasEnumChanged(prev: SymbolMeta, current: SymbolMeta) {
   const prevDeclaration = prev.symbol.declarations[0] as ts.EnumDeclaration;
   const currentDeclaration = current.symbol.declarations[0] as ts.EnumDeclaration;
 
-  // Check previous members
-  // (all previous members must be left intact, otherwise any code that depends on them can possibly have type errors)
-  for (let i = 0; i < prevDeclaration.members.length; i++) {
-    const prevMemberText = prevDeclaration.members[i].getText();
-    const currentMember = currentDeclaration.members.find((member) => prevMemberText === member.getText());
+  const checker = prev.program.getTypeChecker();
+  const prevType = checker.getTypeAtLocation(prevDeclaration);
+  const currentType = checker.getTypeAtLocation(currentDeclaration);
 
-    // Member is missing in the current declaration, or has changed
-    if (!currentMember) {
-      return true;
-    }
-  }
-
-  // We don't care about any new members added at the moment
-  // TODO: check if the statement above is valid
-
-  return false;
+  return !checker.isTypeAssignableTo(prevType, currentType);
 }
 
 export function hasTypeChanged(prev: SymbolMeta, current: SymbolMeta) {
@@ -393,7 +382,7 @@ export function hasTypeChanged(prev: SymbolMeta, current: SymbolMeta) {
   const prevType = checker.getTypeAtLocation(prevDeclaration);
   const currentType = checker.getTypeAtLocation(currentDeclaration);
 
-  return !checker.isTypeComparableTo(prevType, currentType);
+  return !checker.isTypeAssignableTo(prevType, currentType);
 }
 
 export function isFunction(symbol: ts.Symbol) {

--- a/src/commands/compare/enums.test.ts
+++ b/src/commands/compare/enums.test.ts
@@ -110,7 +110,7 @@ describe('Compare enums', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes)).toEqual(['SampleEnum', 'AnotherEnum', 'AnotherEnum.two']);
+    expect(Object.keys(comparison.changes)).toEqual(['SampleEnum', 'AnotherEnum.two']);
     expect(Object.keys(comparison.additions).length).toBe(1);
     expect(Object.keys(comparison.removals).length).toBe(1);
   });

--- a/src/commands/compare/levignore.test.ts
+++ b/src/commands/compare/levignore.test.ts
@@ -63,7 +63,7 @@ describe('Levignore', () => {
 
     // SampleEnum itself changed that's 1 change. SampleEnum.Replace was changed
     // that's 2 changes but, ignored therefore: 1 change
-    expect(Object.keys(comparison.changes).length).toBe(1);
+    expect(Object.keys(comparison.changes).length).toBe(0);
     expect(Object.keys(comparison.additions).length).toBe(0);
 
     // SampleEnum.Remove was removed but ignored

--- a/src/commands/compare/types.test.ts
+++ b/src/commands/compare/types.test.ts
@@ -55,4 +55,45 @@ describe('Compare types', () => {
     expect(Object.keys(comparison.additions).length).toBe(1);
     expect(Object.keys(comparison.removals).length).toBe(0);
   });
+
+  test('ADDING OPTIONAL TYPE - adding a new optional type should not trigger an addition', () => {
+    const prev = `
+      export type Bar = {
+        one: string;
+        two: number;
+      }
+    `;
+    const current = `
+      export type Bar = {
+        one: string;
+        two: number;
+        three?: boolean;
+      }
+    `;
+    const comparison = testCompare(prev, current);
+
+    expect(Object.keys(comparison.changes).length).toBe(0);
+    expect(Object.keys(comparison.additions).length).toBe(1);
+    expect(Object.keys(comparison.removals).length).toBe(0);
+  });
+
+  test('REMOVING DECLARE - removing a declare should not trigger a removal', () => {
+    const prev = `
+      export declare type Bar = {
+        one: string;
+        two: number;
+      }
+    `;
+    const current = `
+      export type Bar = {
+        one: string;
+        two: number;
+      }
+    `;
+    const comparison = testCompare(prev, current);
+
+    expect(Object.keys(comparison.changes).length).toBe(0);
+    expect(Object.keys(comparison.additions).length).toBe(0);
+    expect(Object.keys(comparison.removals).length).toBe(0);
+  });
 });

--- a/src/compiler/imports.ts
+++ b/src/compiler/imports.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import ts from '@tsd/typescript';
 import { ImportInfo, ImportsInfo } from '../types';
 import { createTsProgram } from '../utils/typescript';
 

--- a/src/print/changes.ts
+++ b/src/print/changes.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import Table from 'tty-table';
-import ts from 'typescript';
+import ts from '@tsd/typescript';
 import { Changes } from '../types';
 import { getSymbolDiff } from '../utils/diff';
 import { logInfo } from '../utils/log';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import ts from '@tsd/typescript';
 
 export type SymbolMeta = {
   key: string;
@@ -31,10 +31,15 @@ export type ExportsInfo = {
   program: ts.Program;
 };
 
+export type IgnoreExportOptions = {
+  useTypeComparable?: boolean;
+};
+
 export type IgnoreExportChanges = {
   additions?: RegExp[];
   removals?: RegExp[];
   changes?: RegExp[];
+  options?: IgnoreExportOptions;
 };
 
 export type ImportInfo = {

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -1,4 +1,4 @@
-import ts, { Modifier, NodeArray } from 'typescript';
+import ts, { Modifier, NodeArray } from '@tsd/typescript';
 
 export const COMPILER_OPTIONS = {
   target: ts.ScriptTarget.ES5,

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,6 +925,11 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
+"@tsd/typescript@^5.3.2":
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/@tsd/typescript/-/typescript-5.3.2.tgz#f35055eb6e296dcb3953883237fcf6e2b94be886"
+  integrity sha512-CgECyqLqPRCIcOLJeKvlx4iNs1/IS8SCE/Kb8NlTl3TklLkhtp1jHwZf5VTSTzCH5twlATgdMQfEe+vFzKpHFw==
+
 "@types/babel__core@^7.1.14":
   version "7.1.18"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.18.tgz#1a29abcc411a9c05e2094c98f9a1b7da6cdf49f8"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR replaces the direct use of the `typescript` package for `[@tsd/typescript](https://github.com/tsdjs/typescript)` (MIT License).

`@tsd/typescript` is a drop-in replacement for the `typescript`, it distributes the exact same typescript version but patched so some internal methods that are not available in the programatic API are now available.

Beyond the patching so these methods are exposes `@tsd/typescript` behaves exactly the same as `typescript`

By using these newly available methods we can remove the text-based comparison of types such as variables, enums and types and better detect changes and prevent false positives such as adding new optional types, or declaring changes twice (both as removal and change) in some cases.

## Risks of using `@tsd/typescript`

The risk of using `@tsd/typescript` is that it will not keep up with the latest version of typescript. So far the project have kept in sync for every single version of typescript (the release is automated) and they've done work to keep up with major relases such as typescript 4 and 5.

**Which issue(s) this PR fixes**:

closes https://github.com/grafana/levitate/issues/233
close https://github.com/grafana/levitate/issues/231

**Special notes for your reviewer**:
