### PR TITLE
Add option to output comparison report in json

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -17,6 +17,7 @@ import { isCompatible } from './commands/is-compatible/is-compatible';
 import { logError, logInfo } from './utils/log';
 import { forceDebugExit } from './utils/debug';
 import { readLevignoreFile } from './utils';
+import { printJsonComparison } from './print/comparison-json';
 
 // in DEBUG mode this allows the debugger to connect and disconnect more easily
 if (process.env.DEBUG) {
@@ -52,9 +53,14 @@ yargs
           demandOption: true,
           describe:
             'Current package version - a name of an NPM package, a URL to a tar ball or a local path pointing to a package directory or a single file. (In case it is a directory make sure it contains an `index.d.ts` type definition file.)',
+        })
+        .option('json', {
+          type: 'boolean',
+          default: false,
+          describe: 'Outputs a JSON string representation of the compatibility report.',
         });
     },
-    async function ({ prev, current }: { prev: string; current: string }) {
+    async function ({ prev, current, json }: { prev: string; current: string; json: boolean }) {
       try {
         // Missing CLI arguments
         if (!prev || !current) {
@@ -65,13 +71,21 @@ yargs
           exit(1);
         }
 
+        if (json) {
+          process.env.LEVITATE_SILENT = 'true';
+        }
+
         const levignore = await readLevignoreFile(process.cwd());
         const prevPathResolved = await resolvePackage(prev);
         const currentPathResolved = await resolvePackage(current);
         const comparison = compareExports(prevPathResolved, currentPathResolved, levignore);
         const isBreaking = areChangesBreaking(comparison);
 
-        printComparison(comparison);
+        if (json) {
+          printJsonComparison(comparison);
+        } else {
+          printComparison(comparison);
+        }
 
         if (isBreaking) {
           exit(1);

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -72,6 +72,7 @@ yargs
         }
 
         if (json) {
+          // silences all other output to prevent malformed json output
           process.env.LEVITATE_SILENT = 'true';
         }
 

--- a/src/integration-tests/levitate.test.ts
+++ b/src/integration-tests/levitate.test.ts
@@ -40,4 +40,33 @@ describe('Levitate', () => {
       expect(stdout).toContain('No breaking changes introduced');
     });
   });
+
+  describe('Comparison json output works as expected', () => {
+    const comparisonJsonFixturePath = path.resolve(__dirname, '../../fixtures/compare');
+    it('Outputs a JSON string representation of the compatibility report', async () => {
+      let stdout: string;
+
+      // this command will fail because compare will exit 1
+      try {
+        await execa(
+          nodeBinary,
+          [levitateBinary, 'compare', '--prev', './bundle-old.ts', '--current', './bundle-new.ts', '--json'],
+          {
+            cwd: comparisonJsonFixturePath,
+          }
+        );
+      } catch (e) {
+        stdout = e.stdout;
+      }
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toBeTruthy();
+
+      expect(Object.keys(parsed)).toEqual(['additions', 'removals', 'changes', 'hasBreakingChanges']);
+
+      expect(parsed.hasBreakingChanges).toBe(true);
+      expect(parsed.additions.length).toBe(3);
+      expect(parsed.removals.length).toBe(0);
+      expect(parsed.changes.length).toBe(2);
+    });
+  });
 });

--- a/src/print/comparison-json.ts
+++ b/src/print/comparison-json.ts
@@ -1,0 +1,49 @@
+import { areChangesBreaking } from '../commands/compare/compare';
+import { Comparison } from '../types';
+import { getSymbolDiff } from '../utils/diff';
+
+export function printJsonComparison({ changes, additions, removals, prevProgram, currentProgram }: Comparison) {
+  const isBreaking = areChangesBreaking({ changes, additions, removals, prevProgram, currentProgram });
+  const json = {
+    additions: getJsonAdditions(additions),
+    removals: printJsonRemovals(removals),
+    changes: printJsonChanges(changes),
+    hasBreakingChanges: !!isBreaking,
+  };
+  console.log(JSON.stringify(json, null, 2));
+}
+
+function getJsonAdditions(additions: Comparison['additions']) {
+  return Object.keys(additions).map((name) => ({
+    name,
+    location: additions[name].declarations[0].getSourceFile().fileName,
+    declaration: additions[name].declarations[0].getText(),
+  }));
+}
+
+function printJsonRemovals(removals: Comparison['removals']) {
+  return Object.keys(removals).map((name) => ({
+    name,
+    location: removals[name].declarations[0].getSourceFile().fileName,
+    declaration: removals[name].declarations[0].getText(),
+  }));
+}
+
+function printJsonChanges(changes: Comparison['changes']) {
+  return Object.keys(changes).map((name) => ({
+    name,
+    location: changes[name].current.declarations[0].getSourceFile().fileName,
+    diff: getSymbolDiff({
+      prev: {
+        key: name,
+        symbol: changes[name].prev,
+        program: changes[name].prevProgram,
+      },
+      current: {
+        key: name,
+        symbol: changes[name].current,
+        program: changes[name].currentProgram,
+      },
+    }),
+  }));
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new option to output the compare command in json instead of a markdown report

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/levitate/issues/356
