### PR TITLE
Fix adding optional parameters to a function generating a breaking change

### DIFF
--- a/src/commands/compare/functions.test.ts
+++ b/src/commands/compare/functions.test.ts
@@ -169,4 +169,33 @@ describe('Compare functions', () => {
     expect(Object.keys(comparison.additions).length).toBe(0);
     expect(Object.keys(comparison.removals).length).toBe(0);
   });
+
+  test('Adding an optional parameter to a function should not trigger a breaking change', () => {
+    const prev = `
+      export declare type Bar = {
+        one: string;
+        two: number;
+      }
+
+      export function foo(bar: Bar) {
+        bar.one;
+      }
+    `;
+    const current = `
+      export type Bar = {
+        one: string;
+        two: number;
+        three?: boolean;
+      }
+
+      export function foo(bar: Bar) {
+        bar.one;
+      }
+    `;
+    const comparison = testCompare(prev, current);
+
+    expect(Object.keys(comparison.changes).length).toBe(0);
+    expect(Object.keys(comparison.additions).length).toBe(1);
+    expect(Object.keys(comparison.removals).length).toBe(0);
+  });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue when optional parameters were added to a function types. E.g.:

Old:
```ts
type myParams {
  foo: string
}
function Test(params: myParams) {
  
}
```

New code:

```ts
type myParams {
  foo: string
  newParam?: string
}
function Test(params: myParams) {
  
}
```

Before this Pr levitate would detect the addition of `newParam` as a breaking change, now it solves this case correctly.


Additionally this PR adds code to remove comments from typescript code before doing a plain text comparison. This prevent false positives when only comments inside types and functions

Here's an example PR in grafana/grafana with the problem https://github.com/grafana/grafana/pull/94189