### PR TITLE
Fix: reduces false positives when using multiple files

### DIFF
--- a/fixtures/compare/multi-files/current/index.d.ts
+++ b/fixtures/compare/multi-files/current/index.d.ts
@@ -1,0 +1,3 @@
+import { SynchronousDataTransformerInfo, HistogramTransformerInputs } from './something';
+
+export declare const histogramTransformer: SynchronousDataTransformerInfo<HistogramTransformerInputs>;

--- a/fixtures/compare/multi-files/current/something.d.ts
+++ b/fixtures/compare/multi-files/current/something.d.ts
@@ -1,0 +1,16 @@
+export interface HistogramTransformerInputs {
+  bucketCount?: number;
+  bucketSize?: string | number;
+  bucketOffset?: string | number;
+  combine?: boolean;
+}
+
+export interface DataTransformerInfo<TOptions = any> {
+  operator: (options: TOptions, context: any) => void;
+  isApplicable?: (data: any[]) => boolean;
+}
+
+export interface SynchronousDataTransformerInfo<TOptions = any>
+  extends DataTransformerInfo<TOptions> {
+  transformer: (options: TOptions, context: any) => (frames: any[]) => any[];
+}

--- a/fixtures/compare/multi-files/previous/index.d.ts
+++ b/fixtures/compare/multi-files/previous/index.d.ts
@@ -1,0 +1,3 @@
+import { SynchronousDataTransformerInfo, HistogramTransformerInputs } from './something';
+
+export declare const histogramTransformer: SynchronousDataTransformerInfo<HistogramTransformerInputs>;

--- a/fixtures/compare/multi-files/previous/something.d.ts
+++ b/fixtures/compare/multi-files/previous/something.d.ts
@@ -1,0 +1,16 @@
+export interface HistogramTransformerInputs {
+  bucketCount?: number;
+  bucketSize?: string | number;
+  bucketOffset?: string | number;
+  combine?: boolean;
+}
+
+export interface DataTransformerInfo<TOptions = any> {
+  operator: (options: TOptions, context: any) => void;
+  isApplicable?: (data: any[]) => boolean;
+}
+
+export interface SynchronousDataTransformerInfo<TOptions = any>
+  extends DataTransformerInfo<TOptions> {
+  transformer: (options: TOptions, context: any) => (frames: any[]) => any[];
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "yarn setup-fixtures && yarn build && LEVITATE_SILENT=true yarn vitest",
     "test:ci": "yarn test run",
     "build": "tsc && chmod +x ./dist/bin.js",
-    "dev": "tsc-watch ./src/bin.ts --m commonjs --outDir ./dist --esModuleInterop",
+    "dev": "tsc --watch",
     "dev-compare": "nodemon --exec yarn run dev:compare",
     "dev-imports": "nodemon --exec yarn run dev:imports",
     "dev:compare": "run-s build fixtures:compare",
@@ -75,7 +75,6 @@
     "nodemon": "^3.1.10",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.1.1",
-    "tsc-watch": "^7.0.0",
     "vitest": "^3.1.4"
   },
   "nodemonConfig": {

--- a/src/commands/compare/classes.test.ts
+++ b/src/commands/compare/classes.test.ts
@@ -32,9 +32,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeRemovals(0);
+    expect(comparison).toHaveTypeAdditions(0);
   });
 
   test('REMOVING CLASS - removing a previously exported class should trigger a removal', () => {
@@ -48,9 +48,9 @@ describe('Compare classes', () => {
     const current = ``;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(1);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeRemovals(1);
+    expect(comparison).toHaveTypeAdditions(0);
   });
 
   test('REMOVING A NOT EXPORTED CLASS - removing a previously not exported class should not trigger a removal', () => {
@@ -74,9 +74,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeRemovals(0);
+    expect(comparison).toHaveTypeAdditions(0);
   });
 
   test('NEW VARIABLE - adding a new class variable should not trigger a breaking change', () => {
@@ -116,9 +116,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeRemovals(0);
+    expect(comparison).toHaveTypeAdditions(0);
   });
 
   test('MAKING A VARIABLE OPTIONAL - making a class variable optional should not trigger a breaking change', () => {
@@ -136,9 +136,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeRemovals(0);
+    expect(comparison).toHaveTypeAdditions(0);
   });
 
   // It is the same as adding a new variable
@@ -157,9 +157,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeRemovals(0);
+    expect(comparison).toHaveTypeAdditions(0);
   });
 
   test('CHANGING A PUBLIC MEMBER TO BE PRIVATE - making a previously public class member to be private should trigger a change and removal', () => {
@@ -179,9 +179,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(1);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(2); // 2 became private, thus, removed
+    expect(comparison).toHaveTypeChanges(1);
+    expect(comparison).toHaveTypeRemovals(2); // 2 became private, thus, removed
+    expect(comparison).toHaveTypeAdditions(0);
   });
 
   test('CHANGING A PUBLIC MEMBER TO BE PROTECTED - making a previously public class member to be protected should trigger a breaking change and removal', () => {
@@ -201,9 +201,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(1);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(2); // 2 became protected, thus, removed
+    expect(comparison).toHaveTypeChanges(1);
+    expect(comparison).toHaveTypeRemovals(2); // 2 became protected, thus, removed
+    expect(comparison).toHaveTypeAdditions(0);
   });
 
   // Like this subclasses would not be able to access a previously accessible member.
@@ -224,9 +224,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(1);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(1);
+    expect(comparison).toHaveTypeRemovals(0);
+    expect(comparison).toHaveTypeAdditions(0);
   });
 
   test('CHANGING A PRIVATE MEMBER TO BE PROTECTED - making a previously private class member to be protected should not trigger a breaking change', () => {
@@ -246,9 +246,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeRemovals(0);
+    expect(comparison).toHaveTypeAdditions(0);
   });
 
   test('CHANGING A PRIVATE MEMBER TO BE PUBLIC - making a previously private class member to be public should trigger additions', () => {
@@ -268,9 +268,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(2); // two no longer private, thus, added
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(2); // two no longer private, thus, added
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('CHANGING A PROTECTED MEMBER TO BE PUBLIC - making a previously protected class member to be public should trigger additions', () => {
@@ -290,9 +290,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(2); // two no longer protected, thus, added
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(2); // two no longer protected, thus, added
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('NEW METHOD - adding a new class method should trigger additions', () => {
@@ -317,9 +317,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(1); // newClassMethod added
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(1); // newClassMethod added
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('MAKING A METHOD OPTIONAL - making method optional should not trigger a breaking change', () => {
@@ -339,9 +339,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   // This is similar to adding a new method
@@ -362,9 +362,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('NEW ARGUMENT FOR A CLASS METHOD - adding a new positional argument to any of the methods should trigger a breaking change', () => {
@@ -380,9 +380,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(2); // two changes. one for the class one for the method
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(2); // two changes. one for the class one for the method
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('NEW OPTIONAL ARGUMENT FOR A CLASS METHOD - adding a new optional positional argument to any of the methods should not trigger a breaking change', () => {
@@ -398,9 +398,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('CHANGING RETURN VALUE OF A CLASS METHOD - changing the return value of a method should trigger a breaking change', () => {
@@ -416,9 +416,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(2); // Foo and Foo.getSomething changed
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(2); // Foo and Foo.getSomething changed
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('CHANGING ARGUMENT OF A CLASS METHOD - changing any existing argument of a method should trigger a breaking change', () => {
@@ -442,8 +442,8 @@ describe('Compare classes', () => {
     const comparison = testCompare(prev, current);
 
     expect(Object.keys(comparison.changes)).toEqual(['Foo', 'Foo.methodB']);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('RENAMING METHOD - renaming a class method should trigger a change, addition and removal', () => {
@@ -461,9 +461,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(1); // Foo changed
-    expect(Object.keys(comparison.additions).length).toBe(1); // methodARenamed added
-    expect(Object.keys(comparison.removals).length).toBe(1); // methodA removed
+    expect(comparison).toHaveTypeChanges(1); // Foo changed
+    expect(comparison).toHaveTypeAdditions(1); // methodARenamed added
+    expect(comparison).toHaveTypeRemovals(1); // methodA removed
   });
 
   test('REMOVING METHOD - removing a class method should trigger a change and removal', () => {
@@ -480,9 +480,9 @@ describe('Compare classes', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(1); // Foo changed
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(1); // Foo.methodA removed
+    expect(comparison).toHaveTypeChanges(1); // Foo changed
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(1); // Foo.methodA removed
   });
 
   test('changing the generic should trigger a change in the generic type', () => {
@@ -505,7 +505,7 @@ describe('Compare classes', () => {
     const comparison = testCompare(prev, current);
 
     expect(Object.keys(comparison.changes)).toEqual(['Foo.T']);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 });

--- a/src/commands/compare/compare.test.ts
+++ b/src/commands/compare/compare.test.ts
@@ -48,4 +48,13 @@ describe('Utils compare tests', () => {
     expect(Object.keys(comparison.additions).length).toBe(1);
     expect(Object.keys(comparison.removals).length).toBe(2);
   });
+
+  test('multiple files should not report false positives', async () => {
+    const fixturePath = path.resolve(__dirname, '../../../fixtures/compare/multi-files/');
+    const current = path.resolve(fixturePath, 'current', 'index.d.ts');
+    const prev = path.resolve(fixturePath, 'previous', 'index.d.ts');
+    const ignoredExports = {};
+    const comparison = compareExports(prev, current, ignoredExports);
+    expect(Object.keys(comparison.changes).length).toBe(0);
+  });
 });

--- a/src/commands/compare/compare.test.ts
+++ b/src/commands/compare/compare.test.ts
@@ -29,7 +29,7 @@ describe('Utils compare tests', () => {
     const ignoredExports = {};
 
     const comparison = compareExports(old, newFile, ignoredExports);
-    expect(Object.keys(comparison.changes).length).toBe(1);
+    expect(comparison).toHaveTypeChanges(1);
   });
 
   test('Edge case with props suffix renaming', async () => {
@@ -45,8 +45,8 @@ describe('Utils compare tests', () => {
     expect(Object.keys(comparison.changes)).toEqual(['VizRepeater.componentDidUpdate']);
 
     // these are real detections
-    expect(Object.keys(comparison.additions).length).toBe(1);
-    expect(Object.keys(comparison.removals).length).toBe(2);
+    expect(comparison).toHaveTypeAdditions(1);
+    expect(comparison).toHaveTypeRemovals(2);
   });
 
   test('multiple files should not report false positives', async () => {
@@ -55,6 +55,6 @@ describe('Utils compare tests', () => {
     const prev = path.resolve(fixturePath, 'previous', 'index.d.ts');
     const ignoredExports = {};
     const comparison = compareExports(prev, current, ignoredExports);
-    expect(Object.keys(comparison.changes).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
   });
 });

--- a/src/commands/compare/compare.ts
+++ b/src/commands/compare/compare.ts
@@ -365,7 +365,6 @@ export function hasVariableChanged(prev: SymbolMeta, current: SymbolMeta) {
   const prevType = checker.getTypeAtLocation(prevDeclaration);
   const currentType = checker.getTypeAtLocation(currentDeclaration);
 
-  console.log('Do we even get here2?', prev.symbol.getName());
   return !checker.isTypeIdenticalTo(prevType, currentType);
 }
 

--- a/src/commands/compare/enums.test.ts
+++ b/src/commands/compare/enums.test.ts
@@ -18,9 +18,9 @@ describe('Compare enums', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('REMOVING ENUM - removing a previously exported enum should trigger a removal', () => {
@@ -34,9 +34,9 @@ describe('Compare enums', () => {
     const current = ``;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(4);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(4);
   });
 
   test('NEW VALUE - adding a new value to an enum should trigger an addition', () => {
@@ -57,9 +57,9 @@ describe('Compare enums', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(1);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(1);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('REMOVING VALUE - removing an existing value from an enum should trigger a change and a removal', () => {
@@ -79,8 +79,8 @@ describe('Compare enums', () => {
     const comparison = testCompare(prev, current);
 
     expect(Object.keys(comparison.changes)).toEqual(['SampleEnum']);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(1);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(1);
   });
 
   test('RENAMING VALUE - renaming an existing value in an enum should trigger a change, an addition and a removal', () => {
@@ -111,7 +111,7 @@ describe('Compare enums', () => {
     const comparison = testCompare(prev, current);
 
     expect(Object.keys(comparison.changes)).toEqual(['SampleEnum', 'AnotherEnum', 'AnotherEnum.two']);
-    expect(Object.keys(comparison.additions).length).toBe(1);
-    expect(Object.keys(comparison.removals).length).toBe(1);
+    expect(comparison).toHaveTypeAdditions(1);
+    expect(comparison).toHaveTypeRemovals(1);
   });
 });

--- a/src/commands/compare/functions.test.ts
+++ b/src/commands/compare/functions.test.ts
@@ -12,9 +12,9 @@ describe('Compare functions', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   it('REMOVE FUNCTION - removing a previously exported function should trigger a removal', () => {
@@ -27,9 +27,9 @@ describe('Compare functions', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(1);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(1);
   });
 
   it('NEW FUNCTION - adding a new exported function should trigger an addition', () => {
@@ -44,9 +44,9 @@ describe('Compare functions', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(1);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(1);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   it("CHANGE RETURN VALUE - changing a function's return value type should trigger a breaking change", () => {
@@ -58,8 +58,8 @@ describe('Compare functions', () => {
     const comparison = testCompare(prev, current);
 
     expect(Object.keys(comparison.changes)).toEqual(['foo']);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   it("CHANGE ARGUMENT - changing a function's argument should trigger a breaking change", () => {
@@ -78,8 +78,8 @@ describe('Compare functions', () => {
     const comparison = testCompare(prev, current);
 
     expect(Object.keys(comparison.changes)).toEqual(['foo', 'foo2', 'foo4']);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   it('REMOVE ARGUMENT - removing any argument of a function should trigger a breaking change', () => {
@@ -92,8 +92,8 @@ describe('Compare functions', () => {
     const comparison = testCompare(prev, current);
 
     expect(Object.keys(comparison.changes)).toEqual(['foo']);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   it('NEW ARGUMENT - adding a new positional argument to a function should trigger a breaking change', () => {
@@ -105,9 +105,9 @@ describe('Compare functions', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(1);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(1);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   it('NEW OPTIONAL ARGUMENT - adding a new optional positional argument to a function should not trigger a breaking change', () => {
@@ -119,9 +119,9 @@ describe('Compare functions', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   it("REMOVING DECLARE from a parameter's type should not trigger a removal", () => {
@@ -147,9 +147,9 @@ describe('Compare functions', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   it('Changing the name of a function parmeter should not trigger a breaking change', () => {
@@ -165,9 +165,9 @@ describe('Compare functions', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   it('Adding an optional parameter to a function should not trigger a breaking change', () => {
@@ -194,9 +194,9 @@ describe('Compare functions', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(1);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(1);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   describe('Arrow functions', () => {
@@ -217,9 +217,9 @@ describe('Compare functions', () => {
     `;
       const comparison = testCompare(prev, current);
 
-      expect(Object.keys(comparison.changes).length).toBe(1);
-      expect(Object.keys(comparison.additions).length).toBe(0);
-      expect(Object.keys(comparison.removals).length).toBe(0);
+      expect(comparison).toHaveTypeChanges(1);
+      expect(comparison).toHaveTypeAdditions(0);
+      expect(comparison).toHaveTypeRemovals(0);
     });
 
     it('Detects changes when a non-optional parameter is added', () => {
@@ -240,9 +240,9 @@ describe('Compare functions', () => {
       `;
       const comparison = testCompare(prev, current);
 
-      expect(Object.keys(comparison.changes).length).toBe(1);
-      expect(Object.keys(comparison.additions).length).toBe(0);
-      expect(Object.keys(comparison.removals).length).toBe(0);
+      expect(comparison).toHaveTypeChanges(1);
+      expect(comparison).toHaveTypeAdditions(0);
+      expect(comparison).toHaveTypeRemovals(0);
     });
 
     it('Detect changes when a parameter is removed', () => {
@@ -262,9 +262,9 @@ describe('Compare functions', () => {
       `;
       const comparison = testCompare(prev, current);
 
-      expect(Object.keys(comparison.changes).length).toBe(1);
-      expect(Object.keys(comparison.additions).length).toBe(0);
-      expect(Object.keys(comparison.removals).length).toBe(0);
+      expect(comparison).toHaveTypeChanges(1);
+      expect(comparison).toHaveTypeAdditions(0);
+      expect(comparison).toHaveTypeRemovals(0);
     });
 
     it('Detects changes when a parameter is made optional', () => {
@@ -284,9 +284,9 @@ describe('Compare functions', () => {
       `;
       const comparison = testCompare(prev, current);
 
-      expect(Object.keys(comparison.changes).length).toBe(1);
-      expect(Object.keys(comparison.additions).length).toBe(0);
-      expect(Object.keys(comparison.removals).length).toBe(0);
+      expect(comparison).toHaveTypeChanges(1);
+      expect(comparison).toHaveTypeAdditions(0);
+      expect(comparison).toHaveTypeRemovals(0);
     });
 
     it('Detects changes when a parameter name is changed (inline)', () => {
@@ -298,9 +298,9 @@ describe('Compare functions', () => {
       `;
       const comparison = testCompare(prev, current);
 
-      expect(Object.keys(comparison.changes).length).toBe(1);
-      expect(Object.keys(comparison.additions).length).toBe(0);
-      expect(Object.keys(comparison.removals).length).toBe(0);
+      expect(comparison).toHaveTypeChanges(1);
+      expect(comparison).toHaveTypeAdditions(0);
+      expect(comparison).toHaveTypeRemovals(0);
     });
   });
 
@@ -345,9 +345,9 @@ describe('Compare functions', () => {
       `;
       const comparison = testCompare(prev, current);
 
-      expect(Object.keys(comparison.changes).length).toBe(1);
-      expect(Object.keys(comparison.additions).length).toBe(0);
-      expect(Object.keys(comparison.removals).length).toBe(0);
+      expect(comparison).toHaveTypeChanges(1);
+      expect(comparison).toHaveTypeAdditions(0);
+      expect(comparison).toHaveTypeRemovals(0);
     });
 
     it('Detect changes when a parameter is removed', function () {
@@ -367,9 +367,9 @@ describe('Compare functions', () => {
       `;
       const comparison = testCompare(prev, current);
 
-      expect(Object.keys(comparison.changes).length).toBe(1);
-      expect(Object.keys(comparison.additions).length).toBe(0);
-      expect(Object.keys(comparison.removals).length).toBe(0);
+      expect(comparison).toHaveTypeChanges(1);
+      expect(comparison).toHaveTypeAdditions(0);
+      expect(comparison).toHaveTypeRemovals(0);
     });
 
     it('Detects changes when a parameter is made optional', function () {
@@ -389,9 +389,9 @@ describe('Compare functions', () => {
       `;
       const comparison = testCompare(prev, current);
 
-      expect(Object.keys(comparison.changes).length).toBe(1);
-      expect(Object.keys(comparison.additions).length).toBe(0);
-      expect(Object.keys(comparison.removals).length).toBe(0);
+      expect(comparison).toHaveTypeChanges(1);
+      expect(comparison).toHaveTypeAdditions(0);
+      expect(comparison).toHaveTypeRemovals(0);
     });
 
     it('Detects changes when a parameter name is changed', function () {
@@ -403,9 +403,9 @@ describe('Compare functions', () => {
       `;
       const comparison = testCompare(prev, current);
 
-      expect(Object.keys(comparison.changes).length).toBe(1);
-      expect(Object.keys(comparison.additions).length).toBe(0);
-      expect(Object.keys(comparison.removals).length).toBe(0);
+      expect(comparison).toHaveTypeChanges(1);
+      expect(comparison).toHaveTypeAdditions(0);
+      expect(comparison).toHaveTypeRemovals(0);
     });
   });
 });

--- a/src/commands/compare/interfaces.test.ts
+++ b/src/commands/compare/interfaces.test.ts
@@ -18,9 +18,9 @@ describe('Compare interfaces', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('REMOVING INTERFACE - removing a previously exported interface should trigger removal', () => {
@@ -34,9 +34,9 @@ describe('Compare interfaces', () => {
     const current = ``;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(4); // 1 for the interface, 3 for the properties
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(4); // 1 for the interface, 3 for the properties
   });
 
   test('NEW OPTIONAL VARIABLE - adding a new optional interface variable should trigger an addition', () => {
@@ -57,9 +57,9 @@ describe('Compare interfaces', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(1);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(1);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   // If there is a new variable introduced to the interface then any class already extending that interface can break
@@ -81,9 +81,9 @@ describe('Compare interfaces', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(1);
-    expect(Object.keys(comparison.additions).length).toBe(1); // adding "four"
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(1);
+    expect(comparison).toHaveTypeAdditions(1); // adding "four"
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('REMOVING A VARIABLE - removing a interface variable should trigger a removal', () => {
@@ -102,9 +102,9 @@ describe('Compare interfaces', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(1);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(1);
   });
 
   test('MAKING VARIABLE OPTIONAL - making a variable optional should not breaking change', () => {
@@ -124,9 +124,9 @@ describe('Compare interfaces', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('MAKING VARIABLE NOT OPTIONAL - making a previously optional variable to be not optional should trigger a breaking change', () => {
@@ -146,9 +146,9 @@ describe('Compare interfaces', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(1);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(1);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   // In case a class is already extending this interface then it can break
@@ -176,9 +176,9 @@ describe('Compare interfaces', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(1);
-    expect(Object.keys(comparison.additions).length).toBe(1);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(1);
+    expect(comparison).toHaveTypeAdditions(1);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('REMOVING METHOD - removing a method should trigger a removal', () => {
@@ -201,9 +201,9 @@ describe('Compare interfaces', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(1);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(1);
   });
 
   test('MAKING METHOD OPTIONAL - making a method optional should not trigger a breaking change', () => {
@@ -229,9 +229,9 @@ describe('Compare interfaces', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('MAKING METHOD NOT OPTIONAL - making a previously optional method to be not optional should trigger a breaking change', () => {
@@ -255,8 +255,8 @@ describe('Compare interfaces', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(1);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(1);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 });

--- a/src/commands/compare/levignore.test.ts
+++ b/src/commands/compare/levignore.test.ts
@@ -28,11 +28,11 @@ describe('Levignore', () => {
     const comparison = testCompare(prev, current, ignoredExports);
 
     // SampleEnum itself changed
-    expect(Object.keys(comparison.changes).length).toBe(1);
-    expect(Object.keys(comparison.additions).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(1);
+    expect(comparison).toHaveTypeAdditions(0);
 
     // SampleEnum.Remove was removed but ignored
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test.each([
@@ -63,11 +63,11 @@ describe('Levignore', () => {
 
     // SampleEnum itself changed that's 1 change. SampleEnum.Replace was changed
     // that's 2 changes but, ignored therefore: 1 change
-    expect(Object.keys(comparison.changes).length).toBe(1);
-    expect(Object.keys(comparison.additions).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(1);
+    expect(comparison).toHaveTypeAdditions(0);
 
     // SampleEnum.Remove was removed but ignored
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test.each([
@@ -95,10 +95,10 @@ describe('Levignore', () => {
 
     const comparison = testCompare(prev, current, ignoredExports);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
 
     // SampleEnum.Remove was removed but ignored
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 });

--- a/src/commands/compare/types.test.ts
+++ b/src/commands/compare/types.test.ts
@@ -16,9 +16,9 @@ describe('Compare types', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('CHANGE TYPE - changing a type should trigger a breaking change', () => {
@@ -52,8 +52,8 @@ describe('Compare types', () => {
     const comparison = testCompare(prev, current);
 
     expect(Object.keys(comparison.changes)).toEqual(['Foo', 'Bar']);
-    expect(Object.keys(comparison.additions).length).toBe(1);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeAdditions(1);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('ADDING OPTIONAL TYPE - adding a new optional type should not trigger an addition', () => {
@@ -72,9 +72,9 @@ describe('Compare types', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(1);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(1);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('REMOVING DECLARE - removing a declare should not trigger a removal', () => {
@@ -92,8 +92,8 @@ describe('Compare types', () => {
     `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 });

--- a/src/commands/compare/variables.test.ts
+++ b/src/commands/compare/variables.test.ts
@@ -6,9 +6,9 @@ describe('Compare variables', () => {
     const current = `export const foo: string;`;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('CHANGE VARIABLE VALUE - changing the value of a variable should trigger a breaking change', () => {
@@ -17,8 +17,8 @@ describe('Compare variables', () => {
     const comparison = testCompare(prev, current);
 
     expect(Object.keys(comparison.changes)).toEqual(['foo']);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('CHANGE VARIABLE TYPE - changing the type of a variable should trigger a breaking change', () => {
@@ -27,8 +27,8 @@ describe('Compare variables', () => {
     const comparison = testCompare(prev, current);
 
     expect(Object.keys(comparison.changes)).toEqual(['foo']);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 
   test('RENAMING VARIABLE - renaming a variable should trigger a removal', () => {
@@ -38,9 +38,9 @@ describe('Compare variables', () => {
     const current = ``;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(0);
-    expect(Object.keys(comparison.removals).length).toBe(1);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(0);
+    expect(comparison).toHaveTypeRemovals(1);
   });
 
   test('NEW VARIABLE - adding a new variable should trigger an addition', () => {
@@ -53,8 +53,8 @@ describe('Compare variables', () => {
       `;
     const comparison = testCompare(prev, current);
 
-    expect(Object.keys(comparison.changes).length).toBe(0);
-    expect(Object.keys(comparison.additions).length).toBe(1);
-    expect(Object.keys(comparison.removals).length).toBe(0);
+    expect(comparison).toHaveTypeChanges(0);
+    expect(comparison).toHaveTypeAdditions(1);
+    expect(comparison).toHaveTypeRemovals(0);
   });
 });

--- a/src/tests/setup-matchers.ts
+++ b/src/tests/setup-matchers.ts
@@ -1,0 +1,54 @@
+import { expect } from 'vitest';
+import type { Changes, Exports } from '../types.js';
+import { getTypeAdditionsAsText, getTypeChangesAsText, getTypeRemovalsAsText } from './test-utils.js';
+
+expect.extend({
+  toHaveTypeChanges(received: Changes, expected = 0) {
+    const changesCount = Object.keys(received.changes).length;
+    const pass = changesCount === expected;
+    const message = () => {
+      if (expected > 0 && changesCount === 0) {
+        return `Expected to have type changes, but haven't found any`;
+      }
+
+      return `Expected to have ${expected} changes, but found ${changesCount} \n\n${getTypeChangesAsText(received)}`;
+    };
+
+    return {
+      message,
+      pass,
+    };
+  },
+
+  toHaveTypeRemovals(received: Exports, expected = 0) {
+    const removalsCount = Object.keys(received).length;
+    const pass = removalsCount === expected;
+    const message = () => {
+      if (expected > 0 && removalsCount === 0) {
+        return `Expected to have type removals, but haven't found any`;
+      }
+      return `Expected to have ${expected} removals, but found ${removalsCount} \n\n${getTypeRemovalsAsText(received)}`;
+    };
+
+    return {
+      message,
+      pass,
+    };
+  },
+
+  toHaveTypeAdditions(received: Exports, expected = 0) {
+    const additionsCount = Object.keys(received).length;
+    const pass = additionsCount === expected;
+    const message = () => {
+      if (expected > 0 && additionsCount === 0) {
+        return `Expected to have type additions, but haven't found any`;
+      }
+      return `Expected to have ${expected} additions, but found ${additionsCount} \n\n${getTypeAdditionsAsText(received)}`;
+    };
+
+    return {
+      message,
+      pass,
+    };
+  },
+});

--- a/src/tests/setup-matchers.ts
+++ b/src/tests/setup-matchers.ts
@@ -1,17 +1,18 @@
 import { expect } from 'vitest';
-import type { Changes, Exports } from '../types.js';
+import type { Comparison } from '../types.js';
 import { getTypeAdditionsAsText, getTypeChangesAsText, getTypeRemovalsAsText } from './test-utils.js';
 
 expect.extend({
-  toHaveTypeChanges(received: Changes, expected = 0) {
-    const changesCount = Object.keys(received.changes).length;
+  toHaveTypeChanges(comparison: Comparison, expected: number) {
+    const changes = comparison.changes;
+    const changesCount = Object.keys(changes).length;
     const pass = changesCount === expected;
     const message = () => {
       if (expected > 0 && changesCount === 0) {
         return `Expected to have type changes, but haven't found any`;
       }
 
-      return `Expected to have ${expected} changes, but found ${changesCount} \n\n${getTypeChangesAsText(received)}`;
+      return `Expected to have ${expected} type changes, but found ${changesCount} \n\n${getTypeChangesAsText(changes)}`;
     };
 
     return {
@@ -20,14 +21,15 @@ expect.extend({
     };
   },
 
-  toHaveTypeRemovals(received: Exports, expected = 0) {
-    const removalsCount = Object.keys(received).length;
+  toHaveTypeRemovals(comparison: Comparison, expected: number) {
+    const removals = comparison.removals;
+    const removalsCount = Object.keys(removals).length;
     const pass = removalsCount === expected;
     const message = () => {
       if (expected > 0 && removalsCount === 0) {
         return `Expected to have type removals, but haven't found any`;
       }
-      return `Expected to have ${expected} removals, but found ${removalsCount} \n\n${getTypeRemovalsAsText(received)}`;
+      return `Expected to have ${expected} type removals, but found ${removalsCount} \n\n${getTypeRemovalsAsText(removals)}`;
     };
 
     return {
@@ -36,14 +38,15 @@ expect.extend({
     };
   },
 
-  toHaveTypeAdditions(received: Exports, expected = 0) {
-    const additionsCount = Object.keys(received).length;
+  toHaveTypeAdditions(comparison: Comparison, expected: number) {
+    const additions = comparison.additions;
+    const additionsCount = Object.keys(additions).length;
     const pass = additionsCount === expected;
     const message = () => {
       if (expected > 0 && additionsCount === 0) {
         return `Expected to have type additions, but haven't found any`;
       }
-      return `Expected to have ${expected} additions, but found ${additionsCount} \n\n${getTypeAdditionsAsText(received)}`;
+      return `Expected to have ${expected} type additions, but found ${additionsCount} \n\n${getTypeAdditionsAsText(additions)}`;
     };
 
     return {

--- a/src/tests/test-utils.ts
+++ b/src/tests/test-utils.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import { tmpdir } from 'os';
+import { Changes, Exports } from '../types.js';
 
 export const TMP_DIR = fs.mkdtempSync(path.join(tmpdir(), 'levitate-test'));
 
@@ -17,3 +18,55 @@ export function generateTmpFileWithContent(content: string) {
 export function generateHash() {
   return (Math.random() + 1).toString(36).substring(2);
 }
+
+export function getTypeChangesAsText(changes: Changes) {
+  const exportNames = Object.keys(changes);
+
+  let output = `❌ Type changes (${exportNames.length})\n${'─'.repeat(80)}`;
+
+  exportNames.forEach((exportName, index) => {
+    const change = changes[exportName];
+
+    output += `\n\n${index + 1}. "${exportName}"`;
+
+    // Get the text of the previous and current declarations
+    const prevText = change.prev.declarations?.[0]?.getText() || 'No declaration found';
+    const currentText = change.current.declarations?.[0]?.getText() || 'No declaration found';
+
+    output += `\n  Previous:\n    ${prevText.replace(/\n/g, '\n    ')}`;
+    output += `\n  Current:\n    ${currentText.replace(/\n/g, '\n    ')}`;
+
+    if (index < exportNames.length - 1) {
+      output += `\n  ${'─'.repeat(78)}`;
+    }
+  });
+
+  output += `\n\n${'─'.repeat(80)}\n\n`;
+
+  return output;
+}
+
+export function getTypeRemovalsAsText(removals: Exports) {
+  const exportNames = Object.keys(removals);
+
+  let output = `❌ Type removals (${exportNames.length})\n${'─'.repeat(80)}`;
+
+  output += exportNames.map((exportName) => `- ${exportName}`).join('\n');
+
+  output += `\n\n${'─'.repeat(80)}\n\n`;
+
+  return output;
+}
+
+export function getTypeAdditionsAsText(additions: Exports) {
+  const exportNames = Object.keys(additions);
+
+  let output = `✅ Type additions (${exportNames.length})\n${'─'.repeat(80)}`;
+
+  output += exportNames.map((exportName) => `+ ${exportName}`).join('\n');
+
+  output += `\n\n${'─'.repeat(80)}\n\n`;
+
+  return output;
+}
+

--- a/src/tests/test-utils.ts
+++ b/src/tests/test-utils.ts
@@ -22,7 +22,7 @@ export function generateHash() {
 export function getTypeChangesAsText(changes: Changes) {
   const exportNames = Object.keys(changes);
 
-  let output = `❌ Type changes (${exportNames.length})\n${'─'.repeat(80)}`;
+  let output = `Type changes (${exportNames.length}) explained:\n${'─'.repeat(80)}`;
 
   exportNames.forEach((exportName, index) => {
     const change = changes[exportName];
@@ -33,8 +33,8 @@ export function getTypeChangesAsText(changes: Changes) {
     const prevText = change.prev.declarations?.[0]?.getText() || 'No declaration found';
     const currentText = change.current.declarations?.[0]?.getText() || 'No declaration found';
 
-    output += `\n  Previous:\n    ${prevText.replace(/\n/g, '\n    ')}`;
-    output += `\n  Current:\n    ${currentText.replace(/\n/g, '\n    ')}`;
+    output += `\n\n    Previous:\n      ${prevText.replace(/\n/g, '\n    ')}`;
+    output += `\n    Current:\n      ${currentText.replace(/\n/g, '\n    ')}`;
 
     if (index < exportNames.length - 1) {
       output += `\n  ${'─'.repeat(78)}`;
@@ -49,11 +49,11 @@ export function getTypeChangesAsText(changes: Changes) {
 export function getTypeRemovalsAsText(removals: Exports) {
   const exportNames = Object.keys(removals);
 
-  let output = `❌ Type removals (${exportNames.length})\n${'─'.repeat(80)}`;
+  let output = `Types removed (${exportNames.length}):\n${'─'.repeat(80)}\n`;
 
   output += exportNames.map((exportName) => `- ${exportName}`).join('\n');
 
-  output += `\n\n${'─'.repeat(80)}\n\n`;
+  output += `\n${'─'.repeat(80)}\n\n`;
 
   return output;
 }
@@ -61,11 +61,11 @@ export function getTypeRemovalsAsText(removals: Exports) {
 export function getTypeAdditionsAsText(additions: Exports) {
   const exportNames = Object.keys(additions);
 
-  let output = `✅ Type additions (${exportNames.length})\n${'─'.repeat(80)}`;
+  let output = `Types added (${exportNames.length}):\n${'─'.repeat(80)}\n`;
 
   output += exportNames.map((exportName) => `+ ${exportName}`).join('\n');
 
-  output += `\n\n${'─'.repeat(80)}\n\n`;
+  output += `\n${'─'.repeat(80)}\n\n`;
 
   return output;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,7 @@
     "outDir": "dist",
     "noUnusedLocals": true,
     "target": "ES2022",
-    "types": [
-      "vitest/globals"
-    ]
+    "types": ["vitest/globals", "./vitest.d.ts"]
   },
   "exclude": [
     "./dist",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     include: ['**/*.test.ts'],
     globals: true,
     forceRerunTriggers: ['**/fixtures/**/*'],
+    setupFiles: ['src/tests/setup-matchers.ts'],
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     include: ['**/*.test.ts'],
     globals: true,
+    forceRerunTriggers: ['**/fixtures/**/*'],
   },
 });

--- a/vitest.d.ts
+++ b/vitest.d.ts
@@ -1,0 +1,12 @@
+import 'vitest';
+// Custom matcher types are defined in src/tests/setup-matchers.ts
+
+interface CustomMatchers<R = unknown> {
+  toHaveTypeChanges: (num?: number) => R;
+  toHaveTypeRemovals: (num?: number) => R;
+  toHaveTypeAdditions: (num?: number) => R;
+}
+
+declare module 'vitest' {
+  interface Matchers<T = any> extends CustomMatchers<T> {}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -390,7 +390,6 @@ __metadata:
     ora: "npm:8.2.0"
     prettier: "npm:^3.1.1"
     tar: "npm:^7.4.3"
-    tsc-watch: "npm:^7.0.0"
     tty-table: "npm:^4.1.5"
     typescript: "npm:5.8.3"
     vitest: "npm:^3.1.4"
@@ -2307,13 +2306,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duplexer@npm:~0.1.1":
-  version: 0.1.2
-  resolution: "duplexer@npm:0.1.2"
-  checksum: 10c0/c57bcd4bdf7e623abab2df43a7b5b23d18152154529d166c1e0da6bee341d84c432d157d7e97b32fecb1bf3a8b8857dd85ed81a915789f550637ed25b8e64fc2
-  languageName: node
-  linkType: hard
-
 "eastasianwidth@npm:^0.2.0":
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
@@ -3071,21 +3063,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"event-stream@npm:=3.3.4":
-  version: 3.3.4
-  resolution: "event-stream@npm:3.3.4"
-  dependencies:
-    duplexer: "npm:~0.1.1"
-    from: "npm:~0"
-    map-stream: "npm:~0.1.0"
-    pause-stream: "npm:0.0.11"
-    split: "npm:0.3"
-    stream-combiner: "npm:~0.0.4"
-    through: "npm:~2.3.1"
-  checksum: 10c0/c3ec4e1efc27ab3e73a98923f0a2fa9a19051b87068fea2f3d53d2e4e8c5cfdadf8c8a115b17f3d90b16a46432d396bad91b6e8d0cceb3e449be717a03b75209
-  languageName: node
-  linkType: hard
-
 "execa@npm:^9.5.3":
   version: 9.6.0
   resolution: "execa@npm:9.6.0"
@@ -3304,13 +3281,6 @@ __metadata:
   dependencies:
     fetch-blob: "npm:^3.1.2"
   checksum: 10c0/5392ec484f9ce0d5e0d52fb5a78e7486637d516179b0eb84d81389d7eccf9ca2f663079da56f761355c0a65792810e3b345dc24db9a8bbbcf24ef3c8c88570c6
-  languageName: node
-  linkType: hard
-
-"from@npm:~0":
-  version: 0.1.7
-  resolution: "from@npm:0.1.7"
-  checksum: 10c0/3aab5aea8fe8e1f12a5dee7f390d46a93431ce691b6222dcd5701c5d34378e51ca59b44967da1105a0f90fcdf5d7629d963d51e7ccd79827d19693bdcfb688d4
   languageName: node
   linkType: hard
 
@@ -4615,13 +4585,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"map-stream@npm:~0.1.0":
-  version: 0.1.0
-  resolution: "map-stream@npm:0.1.0"
-  checksum: 10c0/7dd6debe511c1b55d9da75e1efa65a28b1252a2d8357938d2e49b412713c478efbaefb0cdf0ee0533540c3bf733e8f9f71e1a15aa0fe74bf71b64e75bf1576bd
-  languageName: node
-  linkType: hard
-
 "math-intrinsics@npm:^1.0.0, math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
@@ -4827,13 +4790,6 @@ __metadata:
   version: 1.0.5
   resolution: "nice-try@npm:1.0.5"
   checksum: 10c0/95568c1b73e1d0d4069a3e3061a2102d854513d37bcfda73300015b7ba4868d3b27c198d1dbbd8ebdef4112fc2ed9e895d4a0f2e1cce0bd334f2a1346dc9205f
-  languageName: node
-  linkType: hard
-
-"node-cleanup@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "node-cleanup@npm:2.1.2"
-  checksum: 10c0/c59077d7cac01f6315e4417e5d13523e43aa19965b14768581dbd06b37419323abe5f7171afe6aa52b7a483bdd0027e5a5f62a532a2ebec2a8c4cdf163736c92
   languageName: node
   linkType: hard
 
@@ -5326,15 +5282,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pause-stream@npm:0.0.11":
-  version: 0.0.11
-  resolution: "pause-stream@npm:0.0.11"
-  dependencies:
-    through: "npm:~2.3"
-  checksum: 10c0/86f12c64cdaaa8e45ebaca4e39a478e1442db8b4beabc280b545bfaf79c0e2f33c51efb554aace5c069cc441c7b924ba484837b345eaa4ba6fc940d62f826802
-  languageName: node
-  linkType: hard
-
 "picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -5456,17 +5403,6 @@ __metadata:
     object-assign: "npm:^4.1.1"
     react-is: "npm:^16.13.1"
   checksum: 10c0/59ece7ca2fb9838031d73a48d4becb9a7cc1ed10e610517c7d8f19a1e02fa47f7c27d557d8a5702bec3cfeccddc853579832b43f449e54635803f277b1c78077
-  languageName: node
-  linkType: hard
-
-"ps-tree@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "ps-tree@npm:1.2.0"
-  dependencies:
-    event-stream: "npm:=3.3.4"
-  bin:
-    ps-tree: ./bin/ps-tree.js
-  checksum: 10c0/9d1c159e0890db5aa05f84d125193c2190a6c4ecd457596fd25e7611f8f747292a846459dcc0244e27d45529d4cea6d1010c3a2a087fad02624d12fdb7d97c22
   languageName: node
   linkType: hard
 
@@ -6178,15 +6114,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"split@npm:0.3":
-  version: 0.3.3
-  resolution: "split@npm:0.3.3"
-  dependencies:
-    through: "npm:2"
-  checksum: 10c0/88c09b1b4de84953bf5d6c153123a1fbb20addfea9381f70d27b4eb6b2bfbadf25d313f8f5d3fd727d5679b97bfe54da04766b91010f131635bf49e51d5db3fc
-  languageName: node
-  linkType: hard
-
 "sprintf-js@npm:^1.1.3":
   version: 1.1.3
   resolution: "sprintf-js@npm:1.1.3"
@@ -6224,28 +6151,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stream-combiner@npm:~0.0.4":
-  version: 0.0.4
-  resolution: "stream-combiner@npm:0.0.4"
-  dependencies:
-    duplexer: "npm:~0.1.1"
-  checksum: 10c0/8075a94c0eb0f20450a8236cb99d4ce3ea6e6a4b36d8baa7440b1a08cde6ffd227debadffaecd80993bd334282875d0e927ab5b88484625e01970dd251004ff5
-  languageName: node
-  linkType: hard
-
 "stream-transform@npm:^2.1.3":
   version: 2.1.3
   resolution: "stream-transform@npm:2.1.3"
   dependencies:
     mixme: "npm:^0.5.1"
   checksum: 10c0/8a4b40e1ee952869358c12bbb3da3aa9ca30c8964f8f8eef2058a3b6b2202d7a856657ef458a5f2402a464310d177f92d2e4a119667854fce4b17c05e3c180bd
-  languageName: node
-  linkType: hard
-
-"string-argv@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "string-argv@npm:0.3.2"
-  checksum: 10c0/75c02a83759ad1722e040b86823909d9a2fc75d15dd71ec4b537c3560746e33b5f5a07f7332d1e3f88319909f82190843aa2f0a0d8c8d591ec08e93d5b8dec82
   languageName: node
   linkType: hard
 
@@ -6535,13 +6446,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through@npm:2, through@npm:~2.3, through@npm:~2.3.1":
-  version: 2.3.8
-  resolution: "through@npm:2.3.8"
-  checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
-  languageName: node
-  linkType: hard
-
 "tinybench@npm:^2.9.0":
   version: 2.9.0
   resolution: "tinybench@npm:2.9.0"
@@ -6621,22 +6525,6 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10c0/9806a38adea2db0f6aa217ccc6bc9c391ddba338a9fe3080676d0d50ed806d305bb90e8cef0276e793d28c8a929f400abb184ddd7ff83a416959c0f4d2ce754f
-  languageName: node
-  linkType: hard
-
-"tsc-watch@npm:^7.0.0":
-  version: 7.1.1
-  resolution: "tsc-watch@npm:7.1.1"
-  dependencies:
-    cross-spawn: "npm:^7.0.6"
-    node-cleanup: "npm:^2.1.2"
-    ps-tree: "npm:^1.2.0"
-    string-argv: "npm:^0.3.2"
-  peerDependencies:
-    typescript: "*"
-  bin:
-    tsc-watch: dist/lib/tsc-watch.js
-  checksum: 10c0/e69b530c2664213574aa67bb47544cf8d4e55ea46cd2a8929f44d8b8c8a70c3574b9ebe7b1752348690b276ece895f8db86fcf84c1d88be9868eb0705cce2dad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When merging this [PR](https://github.com/grafana/grafana/pull/106442) in Grafana we went from a `single d.ts` file into `multiple d.ts` files. This made Levitate report the same false positives see section below in ALL open grafana PRs. The main fix is the change in `src/commands/compare/compare.ts` but we also made more changes with the test config and matchers. 
```

⚠️ &nbsp;&nbsp;**Possible breaking changes (md version)**&nbsp;&nbsp; ⚠️

<h3>grafana-data</h3><h4>Changes</h4><b>histogramTransformer</b><br>
<sub>/home/runner/work/grafana/grafana/pr/grafana-data/dist/types/transformations/transformers/histogram.d.ts</sub><br>
<pre lang="diff">

</pre><br><br><h3>grafana-runtime</h3><h4>Changes</h4><b>registerEchoBackend</b><br>
<sub>/home/runner/work/grafana/grafana/pr/grafana-runtime/dist/types/services/EchoSrv.d.ts</sub><br>
<pre lang="diff">

</pre><br>
<b>locationService</b><br>
<sub>/home/runner/work/grafana/grafana/pr/grafana-runtime/dist/types/services/LocationService.d.ts</sub><br>
<pre lang="diff">

</pre><br>
<b>setLocationService</b><br>
<sub>/home/runner/work/grafana/grafana/pr/grafana-runtime/dist/types/services/LocationService.d.ts</sub><br>
<pre lang="diff">

</pre><br>
<b>isPageviewEvent</b><br>
<sub>/home/runner/work/grafana/grafana/pr/grafana-runtime/dist/types/analytics/types.d.ts</sub><br>
<pre lang="diff">

</pre><br>
<b>isInteractionEvent</b><br>
<sub>/home/runner/work/grafana/grafana/pr/grafana-runtime/dist/types/analytics/types.d.ts</sub><br>
<pre lang="diff">

</pre><br>
<b>isExperimentViewEvent</b><br>
<sub>/home/runner/work/grafana/grafana/pr/grafana-runtime/dist/types/analytics/types.d.ts</sub><br>
<pre lang="diff">

</pre><br>
<h3>Number of affected plugins: 7</h3><p>To check the plugins affected by each import, click on the links below.</p><h4>Changes</h4><a href="https://ops.grafana-ops.net/d/dmb2o0xnz/imported-property-details?orgId=1&var-propertyName=registerEchoBackend&var-packageName=@grafana/runtime">@grafana/runtime/registerEchoBackend</a><br>
<a href="https://ops.grafana-ops.net/d/dmb2o0xnz/imported-property-details?orgId=1&var-propertyName=locationService&var-packageName=@grafana/runtime">@grafana/runtime/locationService</a><br>
<a href="https://ops.grafana-ops.net/d/dmb2o0xnz/imported-property-details?orgId=1&var-propertyName=setLocationService&var-packageName=@grafana/runtime">@grafana/runtime/setLocationService</a><br>
<a href="https://ops.grafana-ops.net/d/dmb2o0xnz/imported-property-details?orgId=1&var-propertyName=isPageviewEvent&var-packageName=@grafana/runtime">@grafana/runtime/isPageviewEvent</a><br>
<a href="https://ops.grafana-ops.net/d/dmb2o0xnz/imported-property-details?orgId=1&var-propertyName=isInteractionEvent&var-packageName=@grafana/runtime">@grafana/runtime/isInteractionEvent</a><br>
<a href="https://ops.grafana-ops.net/d/dmb2o0xnz/imported-property-details?orgId=1&var-propertyName=isExperimentViewEvent&var-packageName=@grafana/runtime">@grafana/runtime/isExperimentViewEvent</a><br><h3>grafana-schema</h3><h4>Changes</h4><b>defaultTableFieldOptions</b><br>
<sub>/home/runner/work/grafana/grafana/pr/grafana-schema/dist/types/veneer/common.types.d.ts</sub><br>
<pre lang="diff">

</pre><br>
<b>defaultVizLegendOptions</b><br>
<sub>/home/runner/work/grafana/grafana/pr/grafana-schema/dist/types/common/common.gen.d.ts</sub><br>
<pre lang="diff">

</pre><br><br>

[Read our guideline](https://github.com/grafana/grafana/blob/main/contribute/breaking-changes-guide/breaking-changes-guide.md)

* Your pull request merge won't be blocked.
<!-- Sticky Pull Request Commentlevitate-breaking-change-comment -->
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

