### PR TITLE
chore: drop release-please component prefix from tag name

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
## Summary

Adds `include-component-in-tag: false` to `release-please-config.json` so release-please looks for bare `vX.Y.Z` tags (matching this repo's existing convention) instead of `levitate-vX.Y.Z`.

## Background

The first run of `release-please.yml` after #1030 merged completed successfully but did not open a Release PR. Log excerpt:

```
❯ component: levitate
❯ looking for tagName: levitate-v0.17.2
⚠ Expected 1 releases, only found 0
⚠ Missing 1 paths: .
```

Release-please derived a `component` of `levitate` from the package name (`@grafana/levitate`) and expected the previous release tag to be prefixed. With no matching tag, it could not anchor its "commits since last release" calculation and bailed out without opening a PR.

Setting `include-component-in-tag: false` is the canonical fix for single-package repos that use bare `vX.Y.Z` tags.

Run that exhibited the issue: https://github.com/grafana/levitate/actions/runs/26208379072

## Test plan

- [ ] CI passes
- [ ] After merge, `release-please.yml` runs and opens a Release PR proposing `v0.17.3` (there are four `fix:` commits since `v0.17.2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)