### PR TITLE
fix(compare): ignore cosmetic `.d.ts` emit differences in parameter type diffing

### DIFF
--- a/src/commands/compare/compare.ts
+++ b/src/commands/compare/compare.ts
@@ -201,11 +201,16 @@ export function getFunctionParametersDiff({
     // Compare parameter types, but allow if current types have optional fields
     if (ts.isTypeReferenceNode(currentParamType) && ts.isTypeReferenceNode(prevParamType)) {
       const prevType = checker.getTypeFromTypeNode(prevParamType);
-      const currentType = checker.getTypeFromTypeNode(currentParamType);
+      // currentParamType belongs to current.program, so it must be resolved with that program's checker
+      const currentType = current.program.getTypeChecker().getTypeFromTypeNode(currentParamType);
 
       // check if they have different texts as the base line
-      const currentParamSymbolText = removeComments(currentParamSymbol.declarations[0].getText());
-      const prevParamSymbolText = removeComments(prevParamSymbol.declarations[0].getText());
+      // strip modifiers (export/declare/type) first to ignore cosmetic .d.ts emit differences,
+      // then remove comments (order matters: removeComments() would mangle a bare `type Foo` fragment)
+      const currentParamSymbolText = removeComments(
+        stripLeadingModifiers(currentParamSymbol.declarations[0].getText())
+      );
+      const prevParamSymbolText = removeComments(stripLeadingModifiers(prevParamSymbol.declarations[0].getText()));
 
       if (currentParamSymbolText !== prevParamSymbolText) {
         // Use isTypeSubtypeOf to allow more flexible comparison between types
@@ -500,6 +505,13 @@ export function isPublic(declaration: ts.PropertyDeclaration) {
       (modifier) => modifier.kind === ts.SyntaxKind.ProtectedKeyword || modifier.kind === ts.SyntaxKind.PrivateKeyword
     )
   );
+}
+
+// Strips leading `export`/`declare`/`type`/`default` modifiers from declaration text,
+// so cosmetic .d.ts emit differences (e.g. an added `type` on an import, or a rolled-up
+// vs. per-file build adding `export`) aren't mistaken for real API changes.
+export function stripLeadingModifiers(text: string): string {
+  return text.replace(/^(?:export\s+|declare\s+|type\s+|default\s+)+/, '');
 }
 
 export function removeComments(code: string) {

--- a/src/commands/compare/functions.test.ts
+++ b/src/commands/compare/functions.test.ts
@@ -235,16 +235,8 @@ describe('Compare functions', () => {
     });
 
     it('COSMETIC EXPORT KEYWORD - a parameter type (interface) that only gains a leading `export` keyword due to bundling differences should not trigger a breaking change', () => {
-      // Reproduces https://github.com/grafana/levitate/issues/963: comparing
-      // @grafana/data@10.3.12 (a single API-Extractor-rolled-up dist/index.d.ts,
-      // where the interface's home declaration is a bare `interface X { ... }`)
-      // against @grafana/data@12.1.0 (per-file .d.ts output, where the same
-      // interface is declared as `export interface X { ... }`) flagged
-      // `PanelPlugin.useFieldConfig`'s parameter type (`SetFieldConfigOptionsArgs`)
-      // as changed, even though its shape never changed - only the `export`
-      // keyword did. This mirrors that shape (method returning `this`, a
-      // generic interface parameter with a default) as closely as possible
-      // in a self-contained fixture.
+      // Reproduces https://github.com/grafana/levitate/issues/963: a rolled-up vs.
+      // per-file .d.ts build can add an `export` keyword to an interface with no shape change.
       const prev = `
         interface SetFieldConfigOptionsArgs<TFieldConfigOptions = any> {
           standardOptions?: Partial<Record<string, { defaultValue?: any }>>;

--- a/src/commands/compare/functions.test.ts
+++ b/src/commands/compare/functions.test.ts
@@ -202,7 +202,7 @@ describe('Compare functions', () => {
     expect(comparison).toHaveTypeRemovals(0);
   });
 
-  describe('Cosmetic .d.ts emit differences (grafana/levitate#1041, #963)', () => {
+  describe('Cosmetic .d.ts emit differences', () => {
     it('COSMETIC TYPE-ONLY IMPORT MODIFIER - adding an inline `type` modifier to a type-only import of a parameter type should not trigger a breaking change', () => {
       // Reproduces https://github.com/grafana/levitate/issues/1041:
       // the type shape never changed, only whether the import specifier that

--- a/src/commands/compare/functions.test.ts
+++ b/src/commands/compare/functions.test.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+import { TMP_DIR } from '../../tests/test-utils.js';
 import { testCompare } from './utils.js';
 
 describe('Compare functions', () => {
@@ -197,6 +200,78 @@ describe('Compare functions', () => {
     expect(comparison).toHaveTypeChanges(0);
     expect(comparison).toHaveTypeAdditions(1);
     expect(comparison).toHaveTypeRemovals(0);
+  });
+
+  describe('Cosmetic .d.ts emit differences (grafana/levitate#1041, #963)', () => {
+    it('COSMETIC TYPE-ONLY IMPORT MODIFIER - adding an inline `type` modifier to a type-only import of a parameter type should not trigger a breaking change', () => {
+      // Reproduces https://github.com/grafana/levitate/issues/1041:
+      // the type shape never changed, only whether the import specifier that
+      // brings it into scope is emitted as `Foo` or `type Foo`.
+      const helperFilename = path.join(TMP_DIR, 'cosmetic-import-type-modifier-helper.ts');
+      fs.writeFileSync(
+        helperFilename,
+        `
+          export interface PanelMigrationHandler {
+            (payload: unknown): void;
+          }
+        `
+      );
+
+      const prev = `
+        import { PanelMigrationHandler } from './cosmetic-import-type-modifier-helper';
+        export function setMigrationHandler(handler: PanelMigrationHandler): void {};
+      `;
+      const current = `
+        import { type PanelMigrationHandler } from './cosmetic-import-type-modifier-helper';
+        export function setMigrationHandler(handler: PanelMigrationHandler): void {};
+      `;
+      const comparison = testCompare(prev, current);
+
+      fs.unlinkSync(helperFilename);
+
+      expect(comparison).toHaveTypeChanges(0);
+      expect(comparison).toHaveTypeAdditions(0);
+      expect(comparison).toHaveTypeRemovals(0);
+    });
+
+    it('COSMETIC EXPORT KEYWORD - a parameter type (interface) that only gains a leading `export` keyword due to bundling differences should not trigger a breaking change', () => {
+      // Reproduces https://github.com/grafana/levitate/issues/963: comparing
+      // @grafana/data@10.3.12 (a single API-Extractor-rolled-up dist/index.d.ts,
+      // where the interface's home declaration is a bare `interface X { ... }`)
+      // against @grafana/data@12.1.0 (per-file .d.ts output, where the same
+      // interface is declared as `export interface X { ... }`) flagged
+      // `PanelPlugin.useFieldConfig`'s parameter type (`SetFieldConfigOptionsArgs`)
+      // as changed, even though its shape never changed - only the `export`
+      // keyword did. This mirrors that shape (method returning `this`, a
+      // generic interface parameter with a default) as closely as possible
+      // in a self-contained fixture.
+      const prev = `
+        interface SetFieldConfigOptionsArgs<TFieldConfigOptions = any> {
+          standardOptions?: Partial<Record<string, { defaultValue?: any }>>;
+          disableStandardOptions?: string[];
+          useCustomConfig?: (builder: { addCustomEditor: (id: string) => void }) => void;
+        }
+        declare class PanelPlugin<TOptions = any, TFieldConfigOptions extends object = any> {
+          useFieldConfig(config?: SetFieldConfigOptionsArgs<TFieldConfigOptions>): this;
+        }
+        export { SetFieldConfigOptionsArgs, PanelPlugin };
+      `;
+      const current = `
+        export interface SetFieldConfigOptionsArgs<TFieldConfigOptions = any> {
+          standardOptions?: Partial<Record<string, { defaultValue?: any }>>;
+          disableStandardOptions?: string[];
+          useCustomConfig?: (builder: { addCustomEditor: (id: string) => void }) => void;
+        }
+        export declare class PanelPlugin<TOptions = any, TFieldConfigOptions extends object = any> {
+          useFieldConfig(config?: SetFieldConfigOptionsArgs<TFieldConfigOptions>): this;
+        }
+      `;
+      const comparison = testCompare(prev, current);
+
+      expect(comparison).toHaveTypeChanges(0);
+      expect(comparison).toHaveTypeAdditions(0);
+      expect(comparison).toHaveTypeRemovals(0);
+    });
   });
 
   describe('Arrow functions', () => {


### PR DESCRIPTION
**What this PR does / why we need it:**

`compare` reported false "breaking change" diffs on parameter types that only differed in cosmetic `.d.ts` emit output, not actual type shape — e.g.:

```
-PanelMigrationHandler
+type PanelMigrationHandler
```
`getFunctionParametersDiff() ` compared parameter-type declaration text byte-for-byte, so a TS compiler version adding an inline type modifier to imports, or a package switching from a rolled-up to per-file `.d.ts` build, triggered false positives.

Fix: strip leading `export`/`declare`/`type`/`default` modifiers before comparing declaration text, and fix a related cross-`ts.Program` checker misuse in the same function.

Added regression tests (`functions.test.ts`) and validated against the exact real repros from both issues — no longer flagged, full suite passes.

**Which issue(s) this PR fixes:**

Fixes #1041
Fixes #963

**Special notes for your reviewer:**

A related false positive remains on `PanelPlugin.setMigrationHandler` in the 10.3.12→12.1.0 diff — different root cause (symbol resolves to a full declaration on one side, a bare import specifier on the other), worth its own follow-up rather than bundling here.

